### PR TITLE
fix: filter unsupported enable_icc option

### DIFF
--- a/internal/service/network/create.go
+++ b/internal/service/network/create.go
@@ -38,6 +38,8 @@ func (s *service) Create(ctx context.Context, request types.NetworkCreateRequest
 				if v != "0.0.0.0" {
 					s.logger.Warnf("network option com.docker.network.bridge.host_binding_ipv4 is set to %s, but it must be 0.0.0.0", v)
 				}
+			case "com.docker.network.bridge.enable_icc":
+				s.logger.Warnf("network option com.docker.network.bridge.enable_icc is not currently supported in nerdctl", v)
 			case "com.docker.network.bridge.name":
 				bridge = v
 			default:


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
Log a warning if the `enable_icc` is set but not supported

*Testing done:*
Passed all unit and e2e tests


- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
