### PR TITLE
chore: make go version less strict

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/runfinch/finch-daemon
 
-go 1.22.7
+go 1.22
 
 require (
 	github.com/containerd/cgroups/v3 v3.0.3


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
- Makes the go version check align with the N-1 minor version of go, instead of a particular patch version. This makes it easier to build the package for users that are on distros with longer upgrade cycles

*Testing done:*
- Built with various go toolchain versions, no issues


- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
