### PR TITLE
chore: fix failing image load unit test

### DIFF
--- a/internal/service/image/load_test.go
+++ b/internal/service/image/load_test.go
@@ -55,10 +55,10 @@ var _ = Describe("Image Load API", func() {
 		It("should return an error if load image method returns an error", func() {
 			ncClient.EXPECT().GetDataStore().
 				Return(name, nil)
+			logger.EXPECT().Debugf(gomock.Any(), gomock.Any())
 			ncClient.EXPECT().LoadImage(gomock.Any(), gomock.Any(), nil, gomock.Any()).
 				Return(errors.New("error message"))
 			logger.EXPECT().Errorf(gomock.Any(), gomock.Any())
-			logger.EXPECT().Debugf(gomock.Any(), gomock.Any())
 
 			// service should return an error
 			err := service.Load(ctx, inStream, nil, false)


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
Fixed the failing unit test for `"should return an error if load image method returns an error"` by moving `EXPECT.Debugf` directly below the `GetDataStore` method

*Testing done:*
Passed all unit and e2e tests


- [X] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
