### PR TITLE
chore: fix flaky e2e restart test

### DIFF
--- a/e2e/tests/container_create.go
+++ b/e2e/tests/container_create.go
@@ -468,10 +468,10 @@ func ContainerCreate(opt *option.Option) {
 			// check every 500 ms if container restarted
 			ticker := time.NewTicker(500 * time.Millisecond)
 			defer ticker.Stop()
-			maxDuration := 10 * time.Second
+			maxDuration := 30 * time.Second
 			startTime := time.Now()
 			for range ticker.C {
-				// fail testcase if 10 seconds have passed
+				// fail testcase if 30 seconds have passed
 				Expect(time.Since(startTime) < maxDuration).Should(BeTrue())
 
 				// inspect container


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
Increased time to timeout from 10 seconds to 30 seconds

*Testing done:*
Passed all unit and e2e tests


- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.