### PR TITLE
[WIP] fix: Create static binaries on release

### DIFF
--- a/.github/workflows/release-automation.yaml
+++ b/.github/workflows/release-automation.yaml
@@ -39,22 +39,27 @@ jobs:
           export release_tag=${{ env.RELEASE_TAG }}
           export release_version=${release_tag/v/} # Remove v from tag name
           echo "DYNAMIC_BINARY_NAME=finch-daemon-${release_version}-linux-amd64.tar.gz" >> $GITHUB_ENV
+          echo "STATIC_BINARY_NAME=finch-daemon-${release_version}-linux-amd64-static.tar.gz" >> $GITHUB_ENV
 
           mkdir release
       - name: Install Go licenses
         run: go install github.com/google/go-licenses@latest
       - name: Create Third Party Licences File
         run: make licenses
+      - name: setup static dependecies
+        run: sudo apt-get install glibc-static libstdc++-static
       - name: Create release binaries
         run: make RELEASE_TAG=${{ env.RELEASE_TAG }} release
       - name: Verify Release version
         run: |
-          mkdir output
-          tar -xzf release/${{ env.DYNAMIC_BINARY_NAME }} -C ./output
-          BINARY_VERSION=$(./output/finch-daemon --version | grep -oP '\d+\.\d+\.\d+')
+          mkdir -p output/static output/dynamic
+          tar -xzf release/${{ env.DYNAMIC_BINARY_NAME }} -C ./output/dynamic
+          tar -xzf release/${{ env.STATIC_BINARY_NAME }} -C ./output/static
+          DYNAMIC_BINARY_VERSION=$(./output/dynamic/finch-daemon --version | grep -oP '\d+\.\d+\.\d+')
+          STATIC_BINARY_VERSION=$(./output/static/finch-daemon --version | grep -oP '\d+\.\d+\.\d+')
           export release_tag=${{ env.RELEASE_TAG }}
           export release_version=${release_tag/v/}
-          if ["$BINARY_VERSION" != "$release_version"]; then
+          if ["$STATIC_BINARY_VERSION" != "$release_version"] || ["$DYNAMIC_BINARY_VERSION" != "$release_version"]; then
             echo "Version mismatch"
             exit 1
           fi

--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,15 @@ build:
 	$(eval PACKAGE := github.com/runfinch/finch-daemon)
 	$(eval VERSION ?= $(shell git describe --match 'v[0-9]*' --dirty='.modified' --always --tags))
 	$(eval GITCOMMIT := $(shell git rev-parse HEAD)$(shell if ! git diff --no-ext-diff --quiet --exit-code; then echo .m; fi))
+ifneq ($(STATIC),)
+	$(eval GO_BUILDTAGS := osusergo netgo)
+	$(eval LDFLAGS := "-X $(PACKAGE)/version.Version=$(VERSION) -X $(PACKAGE)/version.GitCommit=$(GITCOMMIT) -extldflags '-static'")
+	@echo "Building Static Binary"
+else
+	@echo "Building Dynamic Binary"
 	$(eval LDFLAGS := "-X $(PACKAGE)/version.Version=$(VERSION) -X $(PACKAGE)/version.GitCommit=$(GITCOMMIT)")
-	GOOS=linux go build -ldflags $(LDFLAGS) -v -o $(BINARY) $(PACKAGE)/cmd/finch-daemon
+endif
+	GOOS=linux go build $(if $(GO_BUILDTAGS), -tags "$(GO_BUILDTAGS)")  -ldflags $(LDFLAGS) $(if $(STATIC), ) -v -o $(BINARY) $(PACKAGE)/cmd/finch-daemon
 
 .PHONY: linux
 linux:

--- a/scripts/create-releases.sh
+++ b/scripts/create-releases.sh
@@ -54,6 +54,7 @@ fi
 
 release_version=${1/v/} # Remove v from tag name
 dynamic_binary_name=finch-daemon-${release_version}-linux-${ARCH}.tar.gz
+static_binary_name=finch-daemon-${release_version}-linux-${ARCH}-static.tar.gz
 
 make build
 cp "$LICENSE_FILE" "${OUT_DIR}"
@@ -62,6 +63,14 @@ tar -czvf "$RELEASE_DIR"/"$dynamic_binary_name" -- *
 popd
 rm -rf "{$OUT_DIR:?}"/*
 
+STATIC=1 make build
+cp "$LICENSE_FILE" "${OUT_DIR}"
+pushd "$OUT_DIR"
+tar -czvf "$RELEASE_DIR"/"$static_binary_name" -- *
+popd
+rm -rf "{$OUT_DIR:?}"/*
+
 pushd "$RELEASE_DIR"
 sha256sum "$dynamic_binary_name" > "$RELEASE_DIR"/"$dynamic_binary_name".sha256sum
+sha256sum "$static_binary_name" > "$RELEASE_DIR"/"$static_binary_name".sha256sum
 popd

--- a/scripts/verify-release-artifacts.sh
+++ b/scripts/verify-release-artifacts.sh
@@ -44,7 +44,7 @@ release_tag=$1
 release_version=${release_tag/v/} 
 
 pushd "$release_dir" || exit 1
-tarballs=("finch-daemon-${release_version}-linux-${arch}.tar.gz")
+tarballs=("finch-daemon-${release_version}-linux-${arch}.tar.gz" "finch-daemon-${release_version}-linux-${arch}-static.tar.gz")
 expected_contents=("finch-daemon" "THIRD_PARTY_LICENSES")
 release_is_valid=true
 


### PR DESCRIPTION
Issue #, if available:
The finch-daemon currently only ships dynamically linked binaries.
This change will add static binaries to the release
*Description of changes:*

*Testing done:*



- [ ] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
