### PR TITLE
fix: Add static binaries to release

### DIFF
--- a/.github/workflows/release-automation.yaml
+++ b/.github/workflows/release-automation.yaml
@@ -22,7 +22,7 @@ jobs:
         uses: "WyriHaximus/github-action-get-previous-tag@04e8485ecb6487243907e330d522ff60f02283ce" # v1.4.0
   generate-artifacts:
     needs: get-latest-tag
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     env:
       # Set during setup.
       RELEASE_TAG: ${{ needs.get-latest-tag.outputs.tag }}

--- a/.github/workflows/release-automation.yaml
+++ b/.github/workflows/release-automation.yaml
@@ -22,7 +22,7 @@ jobs:
         uses: "WyriHaximus/github-action-get-previous-tag@04e8485ecb6487243907e330d522ff60f02283ce" # v1.4.0
   generate-artifacts:
     needs: get-latest-tag
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       # Set during setup.
       RELEASE_TAG: ${{ needs.get-latest-tag.outputs.tag }}
@@ -43,22 +43,29 @@ jobs:
           export release_tag=${{ env.RELEASE_TAG }}
           export release_version=${release_tag/v/} # Remove v from tag name
           echo "DYNAMIC_BINARY_NAME=finch-daemon-${release_version}-linux-amd64.tar.gz" >> $GITHUB_ENV
+          echo "STATIC_BINARY_NAME=finch-daemon-${release_version}-linux-amd64-static.tar.gz" >> $GITHUB_ENV
 
           mkdir release
       - name: Install Go licenses
         run: go install github.com/google/go-licenses@latest
       - name: Create Third Party Licences File
         run: make licenses
+      - name: setup static dependecies
+        run: |
+          sudo apt-get update
+          sudo apt-get install libc6-dev -f
       - name: Create release binaries
         run: make RELEASE_TAG=${{ env.RELEASE_TAG }} release
       - name: Verify Release version
         run: |
-          mkdir output
-          tar -xzf release/${{ env.DYNAMIC_BINARY_NAME }} -C ./output
-          BINARY_VERSION=$(./output/finch-daemon --version | grep -oP '\d+\.\d+\.\d+')
+          mkdir -p output/static output/dynamic
+          tar -xzf release/${{ env.DYNAMIC_BINARY_NAME }} -C ./output/dynamic
+          tar -xzf release/${{ env.STATIC_BINARY_NAME }} -C ./output/static
+          DYNAMIC_BINARY_VERSION=$(./output/dynamic/finch-daemon --version | grep -oP '\d+\.\d+\.\d+')
+          STATIC_BINARY_VERSION=$(./output/static/finch-daemon --version | grep -oP '\d+\.\d+\.\d+')
           export release_tag=${{ env.RELEASE_TAG }}
           export release_version=${release_tag/v/}
-          if ["$BINARY_VERSION" != "$release_version"]; then
+          if ["$STATIC_BINARY_VERSION" != "$release_version"] || ["$DYNAMIC_BINARY_VERSION" != "$release_version"]; then
             echo "Version mismatch"
             exit 1
           fi
@@ -98,3 +105,5 @@ jobs:
           files: |
             ${{ needs.generate-artifacts.outputs.dynamic_binary_name }}
             ${{ needs.generate-artifacts.outputs.dynamic_binary_name }}.sha256sum
+            ${{ needs.generate-artifacts.outputs.static_binary_name }}
+            ${{ needs.generate-artifacts.outputs.static_binary_name }}.sha256sum

--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,15 @@ build:
 	$(eval PACKAGE := github.com/runfinch/finch-daemon)
 	$(eval VERSION ?= $(shell git describe --match 'v[0-9]*' --dirty='.modified' --always --tags))
 	$(eval GITCOMMIT := $(shell git rev-parse HEAD)$(shell if ! git diff --no-ext-diff --quiet --exit-code; then echo .m; fi))
-	$(eval LDFLAGS := "-X $(PACKAGE)/version.Version=$(VERSION) -X $(PACKAGE)/version.GitCommit=$(GITCOMMIT) $(EXTRA_LDFLAGS)")
-	GOOS=linux go build -ldflags $(LDFLAGS) -v -o $(BINARY) $(PACKAGE)/cmd/finch-daemon
+ifneq ($(STATIC),)
+	$(eval GO_BUILDTAGS := osusergo netgo)
+	$(eval LDFLAGS := "-X $(PACKAGE)/version.Version=$(VERSION) -X $(PACKAGE)/version.GitCommit=$(GITCOMMIT) -extldflags '-static'")
+	@echo "Building Static Binary"
+else
+	@echo "Building Dynamic Binary"
+	$(eval LDFLAGS := "-X $(PACKAGE)/version.Version=$(VERSION) -X $(PACKAGE)/version.GitCommit=$(GITCOMMIT)")
+endif
+	GOOS=linux go build $(if $(GO_BUILDTAGS), -tags "$(GO_BUILDTAGS)")  -ldflags $(LDFLAGS) $(if $(STATIC), ) -v -o $(BINARY) $(PACKAGE)/cmd/finch-daemon
 
 clean:
 	@rm -f $(BINARIES)

--- a/Makefile
+++ b/Makefile
@@ -27,16 +27,17 @@ LDFLAGS_BASE := -X $(PACKAGE)/version.Version=$(VERSION) -X $(PACKAGE)/version.G
 build:
 ifeq ($(STATIC),)
 	@echo "Building Dynamic Binary"
-	$(eval LDFLAGS := $(LDFLAGS_BASE))
+	CGO_ENABLED=1 GOOS=linux go build \
+		-ldflags "$(LDFLAGS_BASE)" \
+		-v -o $(BINARY) $(PACKAGE)/cmd/finch-daemon
 else
 	@echo "Building Static Binary"
-	$(eval GO_BUILDTAGS := osusergo netgo)
-	$(eval LDFLAGS := $(LDFLAGS_BASE) -extldflags '-static')
-endif
-	GOOS=linux go build \
-		$(if $(GO_BUILDTAGS),-tags "$(GO_BUILDTAGS)") \
-		-ldflags "$(LDFLAGS)" \
+	CGO_ENABLED=0 GOOS=linux go build \
+		-tags netgo \
+		-ldflags "$(LDFLAGS_BASE) -extldflags '-static'" \
 		-v -o $(BINARY) $(PACKAGE)/cmd/finch-daemon
+endif
+
 clean:
 	@rm -f $(BINARIES)
 	@rm -rf $(BIN)

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,13 @@ PACKAGE := github.com/runfinch/finch-daemon
 VERSION := $(shell git describe --match 'v[0-9]*' --dirty='.modified' --always --tags)
 GITCOMMIT := $(shell git rev-parse HEAD)$(shell if ! git diff --no-ext-diff --quiet --exit-code; then echo .m; fi)
 
+ifndef GODEBUG
+	EXTRA_LDFLAGS += -s -w
+endif
+
 LDFLAGS := -X $(PACKAGE)/version.Version=$(VERSION) -X $(PACKAGE)/version.GitCommit=$(GITCOMMIT)
+
+# LDFLAGS += $(EXTRA_LDFLAGS)
 
 ifeq ($(STATIC),)
   GO_BUILDTAGS := osusergo netgo

--- a/scripts/create-releases.sh
+++ b/scripts/create-releases.sh
@@ -54,6 +54,7 @@ fi
 
 release_version=${1/v/} # Remove v from tag name
 dynamic_binary_name=finch-daemon-${release_version}-linux-${ARCH}.tar.gz
+static_binary_name=finch-daemon-${release_version}-linux-${ARCH}-static.tar.gz
 
 make build
 cp "$LICENSE_FILE" "${OUT_DIR}"
@@ -62,6 +63,14 @@ tar -czvf "$RELEASE_DIR"/"$dynamic_binary_name" -- *
 popd
 rm -rf "{$OUT_DIR:?}"/*
 
+STATIC=1 make build
+cp "$LICENSE_FILE" "${OUT_DIR}"
+pushd "$OUT_DIR"
+tar -czvf "$RELEASE_DIR"/"$static_binary_name" -- *
+popd
+rm -rf "{$OUT_DIR:?}"/*
+
 pushd "$RELEASE_DIR"
 sha256sum "$dynamic_binary_name" > "$RELEASE_DIR"/"$dynamic_binary_name".sha256sum
+sha256sum "$static_binary_name" > "$RELEASE_DIR"/"$static_binary_name".sha256sum
 popd

--- a/scripts/verify-release-artifacts.sh
+++ b/scripts/verify-release-artifacts.sh
@@ -44,7 +44,7 @@ release_tag=$1
 release_version=${release_tag/v/} 
 
 pushd "$release_dir" || exit 1
-tarballs=("finch-daemon-${release_version}-linux-${arch}.tar.gz")
+tarballs=("finch-daemon-${release_version}-linux-${arch}.tar.gz" "finch-daemon-${release_version}-linux-${arch}-static.tar.gz")
 expected_contents=("finch-daemon" "THIRD_PARTY_LICENSES")
 release_is_valid=true
 


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*

*Testing done:*
- verified o/p of finch daemon binaries from [fork release](https://github.com/coderbirju/finch-daemon/releases/tag/v0.9.1)
- dynamic 
`$ ldd ./finch-daemon
 linux-vdso.so.1 (0x00007ffc112ba000)
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x0000778e82c00000)
        /lib64/ld-linux-x86-64.so.2 (0x0000778e82e43000)`

`$ file ./finc-daemon`
`./finch-daemon: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, BuildID[sha1]=3db17231b58a26bfc842a2f4101034c909cee7e8, for GNU/Linux 3.2.0, with debug_info, not stripped`

- static
`$ ldd ./finch-daemon
not a dynamic executable
`

`$ file ./finc-daemon`
`./finch-daemon: ELF 64-bit LSB executable, x86-64, version 1 (GNU/Linux), statically linked, BuildID[sha1]=24763e08999dd8508011f063060edc54e00b8448, for GNU/Linux 3.2.0, with debug_info, not stripped`


- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
