### PR TITLE
chore: strip debug info and add the clean build target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,13 +13,21 @@ BINDIR ?= $(PREFIX)/bin
 
 BINARY = $(addprefix bin/,finch-daemon)
 
+ifndef GODEBUG
+	EXTRA_LDFLAGS += -s -w
+endif
+
 .PHONY: build
 build:
 	$(eval PACKAGE := github.com/runfinch/finch-daemon)
 	$(eval VERSION ?= $(shell git describe --match 'v[0-9]*' --dirty='.modified' --always --tags))
 	$(eval GITCOMMIT := $(shell git rev-parse HEAD)$(shell if ! git diff --no-ext-diff --quiet --exit-code; then echo .m; fi))
-	$(eval LDFLAGS := "-X $(PACKAGE)/version.Version=$(VERSION) -X $(PACKAGE)/version.GitCommit=$(GITCOMMIT)")
+	$(eval LDFLAGS := "-X $(PACKAGE)/version.Version=$(VERSION) -X $(PACKAGE)/version.GitCommit=$(GITCOMMIT) $(EXTRA_LDFLAGS)")
 	GOOS=linux go build -ldflags $(LDFLAGS) -v -o $(BINARY) $(PACKAGE)/cmd/finch-daemon
+
+clean:
+	@rm -f $(BINARIES)
+	@rm -rf $(BIN)
 
 .PHONY: linux
 linux:


### PR DESCRIPTION
Strip the debug info by default to reduce the output binary size.

Also added the "clean" build target.

- [X] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
