### PR TITLE
fix: Remove bump-patch-for-minor-pre-major

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,7 +2,6 @@
     "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
     "release-type": "go",
     "bump-minor-pre-major": true,
-    "bump-patch-for-minor-pre-major": true,
     "changelog-sections": [
         {
             "type": "build",


### PR DESCRIPTION
Issue #, if available:
Fixes an issue with release please that made it bump the patch version instead of minor version on new feature commits

*Description of changes:*

*Testing done:*



- [ ] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
