### PR TITLE
fix: return an error if custom bridge name is not set successfully

### DIFF
--- a/internal/service/network/driver/bridge.go
+++ b/internal/service/network/driver/bridge.go
@@ -92,7 +92,7 @@ func (bd *bridgeDriver) HandlePostCreate(net *netutil.NetworkConfig) (string, er
 		// Since nerdctl currently does not support custom bridge names,
 		// we explicitly override bridge name in the conflist file for the network that was just created
 		if err = bd.setBridgeName(net, bridgeName); err != nil {
-			warning = fmt.Sprintf("Failed to set network bridge name %s: %s", bridgeName, err)
+			return "", fmt.Errorf("failed to set network bridge name %s: %s", bridgeName, err)
 		}
 	}
 


### PR DESCRIPTION
Issue #, if available:
Addressing a comment from the PR https://github.com/runfinch/finch-daemon/pull/69#discussion_r1810770866

*Description of changes:*

If the option to configure custom bridge name is set, finch-daemon will try to set the bridge name by updating the CNI conflist of the network. However, on failure, it will simply return a warning instead of failing. This change returns an explicit error if an error is encountered. 

The created Network will be removed as part of a defer cleanup in Create.

*Testing done:*



- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
