### PR TITLE
feat: Update container inspect with size option

### DIFF
--- a/api/handlers/container/container.go
+++ b/api/handlers/container/container.go
@@ -26,7 +26,7 @@ type Service interface {
 	Stop(ctx context.Context, cid string, timeout *time.Duration) error
 	Restart(ctx context.Context, cid string, timeout time.Duration) error
 	Create(ctx context.Context, image string, cmd []string, createOpt ncTypes.ContainerCreateOptions, netOpt ncTypes.NetworkOptions) (string, error)
-	Inspect(ctx context.Context, cid string) (*types.Container, error)
+	Inspect(ctx context.Context, cid string, size bool) (*types.Container, error)
 	WriteFilesAsTarArchive(filePath string, writer io.Writer, slashDot bool) error
 	Attach(ctx context.Context, cid string, opts *types.AttachOptions) error
 	List(ctx context.Context, listOpts ncTypes.ContainerListOptions) ([]types.ContainerListItem, error)

--- a/api/handlers/container/container_test.go
+++ b/api/handlers/container/container_test.go
@@ -104,7 +104,7 @@ var _ = Describe("Container API", func() {
 		})
 		It("should call container inspect method", func() {
 			// setup mocks
-			service.EXPECT().Inspect(gomock.Any(), gomock.Any()).Return(nil, fmt.Errorf("error from inspect api"))
+			service.EXPECT().Inspect(gomock.Any(), gomock.Any(), false).Return(nil, fmt.Errorf("error from inspect api"))
 			req, _ = http.NewRequest(http.MethodGet, "/containers/123/json", nil)
 			// call the API to check if it returns the error generated from inspect method
 			router.ServeHTTP(rr, req)

--- a/api/handlers/container/container_test.go
+++ b/api/handlers/container/container_test.go
@@ -104,7 +104,7 @@ var _ = Describe("Container API", func() {
 		})
 		It("should call container inspect method", func() {
 			// setup mocks
-			service.EXPECT().Inspect(gomock.Any(), gomock.Any(), false).Return(nil, fmt.Errorf("error from inspect api"))
+			service.EXPECT().Inspect(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, fmt.Errorf("error from inspect api"))
 			req, _ = http.NewRequest(http.MethodGet, "/containers/123/json", nil)
 			// call the API to check if it returns the error generated from inspect method
 			router.ServeHTTP(rr, req)

--- a/api/handlers/container/inspect.go
+++ b/api/handlers/container/inspect.go
@@ -5,6 +5,7 @@ package container
 
 import (
 	"net/http"
+	"strconv"
 
 	"github.com/containerd/containerd/v2/pkg/namespaces"
 	"github.com/gorilla/mux"
@@ -16,8 +17,12 @@ import (
 
 func (h *handler) inspect(w http.ResponseWriter, r *http.Request) {
 	cid := mux.Vars(r)["id"]
+	sizeflag, err := strconv.ParseBool(r.URL.Query().Get("size"))
+	if err != nil {
+		sizeflag = false
+	}
 	ctx := namespaces.WithNamespace(r.Context(), h.Config.Namespace)
-	c, err := h.service.Inspect(ctx, cid)
+	c, err := h.service.Inspect(ctx, cid, sizeflag)
 	// map the error into http status code and send response.
 	if err != nil {
 		var code int

--- a/api/handlers/container/inspect_test.go
+++ b/api/handlers/container/inspect_test.go
@@ -56,7 +56,7 @@ var _ = Describe("Container Inspect API", func() {
 	})
 	Context("handler", func() {
 		It("should return inspect object and 200 status code upon success", func() {
-			service.EXPECT().Inspect(gomock.Any(), cid).Return(&resp, nil)
+			service.EXPECT().Inspect(gomock.Any(), cid, false).Return(&resp, nil)
 
 			// handler should return response object with 200 status code
 			h.inspect(rr, req)
@@ -64,7 +64,7 @@ var _ = Describe("Container Inspect API", func() {
 			Expect(rr).Should(HaveHTTPStatus(http.StatusOK))
 		})
 		It("should return 404 status code if container was not found", func() {
-			service.EXPECT().Inspect(gomock.Any(), cid).Return(nil, errdefs.NewNotFound(fmt.Errorf("no such container")))
+			service.EXPECT().Inspect(gomock.Any(), cid, false).Return(nil, errdefs.NewNotFound(fmt.Errorf("no such container")))
 			logger.EXPECT().Debugf(gomock.Any(), gomock.Any())
 
 			// handler should return error message with 404 status code
@@ -73,7 +73,7 @@ var _ = Describe("Container Inspect API", func() {
 			Expect(rr).Should(HaveHTTPStatus(http.StatusNotFound))
 		})
 		It("should return 500 status code if service returns an error message", func() {
-			service.EXPECT().Inspect(gomock.Any(), cid).Return(nil, fmt.Errorf("error"))
+			service.EXPECT().Inspect(gomock.Any(), cid, false).Return(nil, fmt.Errorf("error"))
 			logger.EXPECT().Debugf(gomock.Any(), gomock.Any())
 
 			// handler should return error message

--- a/api/handlers/container/inspect_test.go
+++ b/api/handlers/container/inspect_test.go
@@ -32,6 +32,8 @@ var _ = Describe("Container Inspect API", func() {
 		req      *http.Request
 		resp     types.Container
 		respJSON []byte
+		req2     *http.Request
+		err      error
 	)
 	BeforeEach(func() {
 		mockCtrl = gomock.NewController(GinkgoT())
@@ -42,14 +44,30 @@ var _ = Describe("Container Inspect API", func() {
 		h = newHandler(service, &c, logger)
 		rr = httptest.NewRecorder()
 		cid = "123"
-		var err error
-		req, err = http.NewRequest(http.MethodGet, fmt.Sprintf("/containers/%s/json", cid), nil)
-		Expect(err).Should(BeNil())
-		req = mux.SetURLVars(req, map[string]string{"id": "123"})
+
+		// Create a helper function to create and set up requests
+		createRequest := func(sizeParam bool) *http.Request {
+			url := fmt.Sprintf("/containers/%s/json", cid)
+			if sizeParam {
+				url += "?size=true"
+			}
+			req, err := http.NewRequest(http.MethodGet, url, nil)
+			Expect(err).Should(BeNil())
+			return mux.SetURLVars(req, map[string]string{"id": cid})
+		}
+
+		// Create both requests using the helper function
+		req = createRequest(false)
+		req2 = createRequest(true)
+
+		sizeRw := int64(1000)
+		sizeRootFs := int64(5000)
 		resp = types.Container{
-			ID:    cid,
-			Image: "test-image",
-			Name:  "/test-container",
+			ID:         cid,
+			Image:      "test-image",
+			Name:       "/test-container",
+			SizeRw:     &sizeRw,
+			SizeRootFs: &sizeRootFs,
 		}
 		respJSON, err = json.Marshal(resp)
 		Expect(err).Should(BeNil())
@@ -62,6 +80,21 @@ var _ = Describe("Container Inspect API", func() {
 			h.inspect(rr, req)
 			Expect(rr.Body).Should(MatchJSON(respJSON))
 			Expect(rr).Should(HaveHTTPStatus(http.StatusOK))
+		})
+		It("should return inspect object with size information and 200 status code upon success", func() {
+			service.EXPECT().Inspect(gomock.Any(), cid, true).Return(&resp, nil)
+
+			h.inspect(rr, req2)
+			Expect(rr.Body).Should(MatchJSON(respJSON))
+			Expect(rr).Should(HaveHTTPStatus(http.StatusOK))
+
+			var returnedResp types.Container
+			err := json.Unmarshal(rr.Body.Bytes(), &returnedResp)
+			Expect(err).Should(BeNil())
+			Expect(returnedResp.SizeRw).ShouldNot(BeNil())
+			Expect(*returnedResp.SizeRw).Should(Equal(int64(1000)))
+			Expect(returnedResp.SizeRootFs).ShouldNot(BeNil())
+			Expect(*returnedResp.SizeRootFs).Should(Equal(int64(5000)))
 		})
 		It("should return 404 status code if container was not found", func() {
 			service.EXPECT().Inspect(gomock.Any(), cid, false).Return(nil, errdefs.NewNotFound(fmt.Errorf("no such container")))

--- a/api/types/container_types.go
+++ b/api/types/container_types.go
@@ -173,8 +173,8 @@ type Container struct {
 	// TODO: ExecIDs         []string
 	// TODO: HostConfig      *container.HostConfig
 	// TODO: GraphDriver     GraphDriverData
-	// TODO: SizeRw     *int64 `json:",omitempty"`
-	// TODO: SizeRootFs *int64 `json:",omitempty"`
+	SizeRw     *int64 `json:",omitempty"`
+	SizeRootFs *int64 `json:",omitempty"`
 
 	Mounts          []dockercompat.MountPoint
 	Config          *ContainerConfig

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -48,6 +48,7 @@ func TestRun(t *testing.T) {
 		tests.ContainerAttach(opt)
 		tests.ContainerLogs(opt)
 		tests.ContainerKill(opt)
+		tests.ContainerInspect(opt)
 
 		// functional test for volume APIs
 		tests.VolumeList(opt)

--- a/e2e/tests/container_inspect.go
+++ b/e2e/tests/container_inspect.go
@@ -1,0 +1,87 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package tests
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/runfinch/common-tests/command"
+	"github.com/runfinch/common-tests/option"
+
+	"github.com/runfinch/finch-daemon/api/types"
+	"github.com/runfinch/finch-daemon/e2e/client"
+)
+
+// ContainerInspect tests the `GET containers/{id}/json` API.
+func ContainerInspect(opt *option.Option) {
+	Describe("inspect container", func() {
+		var (
+			uClient           *http.Client
+			version           string
+			containerId       string
+			containerName     string
+			wantContainerName string
+		)
+		BeforeEach(func() {
+			uClient = client.NewClient(GetDockerHostUrl())
+			version = GetDockerApiVersion()
+			containerName = testContainerName
+			wantContainerName = fmt.Sprintf("/%s", containerName)
+			containerId = command.StdoutStr(opt, "run", "-d", "--name", containerName, defaultImage, "sleep", "infinity")
+		})
+		AfterEach(func() {
+			command.RemoveAll(opt)
+		})
+
+		It("should inspect the container by ID", func() {
+			res, err := uClient.Get(client.ConvertToFinchUrl(version, fmt.Sprintf("/containers/%s/json", containerId)))
+			Expect(err).Should(BeNil())
+			Expect(res.StatusCode).Should(Equal(http.StatusOK))
+			var got types.Container
+			err = json.NewDecoder(res.Body).Decode(&got)
+			Expect(err).Should(BeNil())
+			Expect(got.ID).Should(Equal(containerId))
+			Expect(got.Name).Should(Equal(wantContainerName))
+			Expect(got.State.Status).Should(Equal("running"))
+		})
+
+		It("should inspect the container by name", func() {
+			res, err := uClient.Get(client.ConvertToFinchUrl(version, fmt.Sprintf("/containers/%s/json", containerName)))
+			Expect(err).Should(BeNil())
+			Expect(res.StatusCode).Should(Equal(http.StatusOK))
+			var got types.Container
+			err = json.NewDecoder(res.Body).Decode(&got)
+			Expect(err).Should(BeNil())
+			Expect(got.ID).Should(Equal(containerId))
+			Expect(got.Name).Should(Equal(wantContainerName))
+			Expect(got.State.Status).Should(Equal("running"))
+		})
+
+		It("should return size information when size parameter is true", func() {
+			res, err := uClient.Get(client.ConvertToFinchUrl(version, fmt.Sprintf("/containers/%s/json?size=1", containerId)))
+			Expect(err).Should(BeNil())
+			Expect(res.StatusCode).Should(Equal(http.StatusOK))
+			var got types.Container
+			err = json.NewDecoder(res.Body).Decode(&got)
+			Expect(err).Should(BeNil())
+			Expect(got.SizeRw).ShouldNot(BeNil())
+			Expect(got.SizeRootFs).ShouldNot(BeNil())
+		})
+
+		It("should return 404 error when container does not exist", func() {
+			res, err := uClient.Get(client.ConvertToFinchUrl(version, "/containers/nonexistent/json"))
+			Expect(err).Should(BeNil())
+			Expect(res.StatusCode).Should(Equal(http.StatusNotFound))
+			body, err := io.ReadAll(res.Body)
+			Expect(err).Should(BeNil())
+			defer res.Body.Close()
+			Expect(body).Should(MatchJSON(`{"message": "no such container: nonexistent"}`))
+		})
+	})
+}

--- a/internal/service/container/inspect.go
+++ b/internal/service/container/inspect.go
@@ -18,13 +18,13 @@ import (
 
 const networkPrefix = "unknown-eth"
 
-func (s *service) Inspect(ctx context.Context, cid string) (*types.Container, error) {
+func (s *service) Inspect(ctx context.Context, cid string, sizeFlag bool) (*types.Container, error) {
 	c, err := s.getContainer(ctx, cid)
 	if err != nil {
 		return nil, err
 	}
 
-	inspect, err := s.nctlContainerSvc.InspectContainer(ctx, c)
+	inspect, err := s.nctlContainerSvc.InspectContainer(ctx, c, sizeFlag)
 	if err != nil {
 		return nil, err
 	}
@@ -47,6 +47,8 @@ func (s *service) Inspect(ctx context.Context, cid string) (*types.Container, er
 		AppArmorProfile: inspect.AppArmorProfile,
 		Mounts:          inspect.Mounts,
 		NetworkSettings: inspect.NetworkSettings,
+		SizeRw:          inspect.SizeRw,
+		SizeRootFs:      inspect.SizeRootFs,
 	}
 
 	cont.Config = &types.ContainerConfig{

--- a/internal/service/container/list.go
+++ b/internal/service/container/list.go
@@ -26,7 +26,7 @@ func (s *service) List(ctx context.Context, listOpts ncTypes.ContainerListOption
 			return nil, err
 		}
 
-		ci, err := s.nctlContainerSvc.InspectContainer(ctx, c)
+		ci, err := s.nctlContainerSvc.InspectContainer(ctx, c, false)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/service/container/list_test.go
+++ b/internal/service/container/list_test.go
@@ -69,7 +69,7 @@ var _ = Describe("Container List API ", func() {
 				containers, nil)
 			cdClient.EXPECT().SearchContainer(gomock.Any(), gomock.Any()).AnyTimes().Return(
 				[]containerd.Container{con}, nil)
-			ncClient.EXPECT().InspectContainer(gomock.Any(), gomock.Any()).AnyTimes().Return(
+			ncClient.EXPECT().InspectContainer(gomock.Any(), gomock.Any(), false).AnyTimes().Return(
 				&dockercompat.Container{
 					NetworkSettings: expectedNS,
 					Mounts:          nil,

--- a/mocks/mocks_backend/nerdctlcontainersvc.go
+++ b/mocks/mocks_backend/nerdctlcontainersvc.go
@@ -91,18 +91,18 @@ func (mr *MockNerdctlContainerSvcMockRecorder) GetNerdctlExe() *gomock.Call {
 }
 
 // InspectContainer mocks base method.
-func (m *MockNerdctlContainerSvc) InspectContainer(arg0 context.Context, arg1 client.Container) (*dockercompat.Container, error) {
+func (m *MockNerdctlContainerSvc) InspectContainer(arg0 context.Context, arg1 client.Container, arg2 bool) (*dockercompat.Container, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "InspectContainer", arg0, arg1)
+	ret := m.ctrl.Call(m, "InspectContainer", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*dockercompat.Container)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // InspectContainer indicates an expected call of InspectContainer.
-func (mr *MockNerdctlContainerSvcMockRecorder) InspectContainer(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockNerdctlContainerSvcMockRecorder) InspectContainer(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InspectContainer", reflect.TypeOf((*MockNerdctlContainerSvc)(nil).InspectContainer), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InspectContainer", reflect.TypeOf((*MockNerdctlContainerSvc)(nil).InspectContainer), arg0, arg1, arg2)
 }
 
 // InspectNetNS mocks base method.

--- a/mocks/mocks_container/containersvc.go
+++ b/mocks/mocks_container/containersvc.go
@@ -113,18 +113,18 @@ func (mr *MockServiceMockRecorder) GetPathToFilesInContainer(arg0, arg1, arg2 in
 }
 
 // Inspect mocks base method.
-func (m *MockService) Inspect(arg0 context.Context, arg1 string) (*types0.Container, error) {
+func (m *MockService) Inspect(arg0 context.Context, arg1 string, arg2 bool) (*types0.Container, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Inspect", arg0, arg1)
+	ret := m.ctrl.Call(m, "Inspect", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*types0.Container)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Inspect indicates an expected call of Inspect.
-func (mr *MockServiceMockRecorder) Inspect(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockServiceMockRecorder) Inspect(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Inspect", reflect.TypeOf((*MockService)(nil).Inspect), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Inspect", reflect.TypeOf((*MockService)(nil).Inspect), arg0, arg1, arg2)
 }
 
 // Kill mocks base method.


### PR DESCRIPTION
Issue #, if available:
Adds SizeRW and SizeRootFs options to inspect response

Inspect response without size option passed
```
{
  "Id": "842c7a142d2249f0c25e654a10e4fb10ac5ae2c7fa6cd6fa8d94dbc5fd44ac2c",
  "Created": "2025-02-10T19:43:07.960689829Z",
  "Path": "sleep",
  "Args": [],
  "State": { ...},
  "Image": "docker.io/library/ubuntu:latest",
  "ResolvConfPath": "/var/lib/nerdctl/1935db59/containers/finch/842c7a142d2249f0c25e654a10e4fb10ac5ae2c7fa6cd6fa8d94dbc5fd44ac2c/resolv.conf",
  "HostnamePath": "/var/lib/nerdctl/1935db59/containers/finch/842c7a142d2249f0c25e654a10e4fb10ac5ae2c7fa6cd6fa8d94dbc5fd44ac2c/hostname",
  "LogPath": "/var/lib/nerdctl/1935db59/containers/finch/842c7a142d2249f0c25e654a10e4fb10ac5ae2c7fa6cd6fa8d94dbc5fd44ac2c/842c7a142d2249f0c25e654a10e4fb10ac5ae2c7fa6cd6fa8d94dbc5fd44ac2c-json.log",
  "Name": "/my-test-container",
  "RestartCount": 0,
  "Driver": "overlayfs",
  "Platform": "linux",
  "AppArmorProfile": "",
   "Mounts": [...],
  "Config": {...}
  "NetworkSettings": null
}
```

Inspect response with size set (`containers/<id>/json?size=1`)

```
{
  "Id": "842c7a142d2249f0c25e654a10e4fb10ac5ae2c7fa6cd6fa8d94dbc5fd44ac2c",
  "Created": "2025-02-10T19:43:07.960689829Z",
  "Path": "sleep",
  "Args": [],
  "State": { ...},
  "Image": "docker.io/library/ubuntu:latest",
  "ResolvConfPath": "/var/lib/nerdctl/1935db59/containers/finch/842c7a142d2249f0c25e654a10e4fb10ac5ae2c7fa6cd6fa8d94dbc5fd44ac2c/resolv.conf",
  "HostnamePath": "/var/lib/nerdctl/1935db59/containers/finch/842c7a142d2249f0c25e654a10e4fb10ac5ae2c7fa6cd6fa8d94dbc5fd44ac2c/hostname",
  "LogPath": "/var/lib/nerdctl/1935db59/containers/finch/842c7a142d2249f0c25e654a10e4fb10ac5ae2c7fa6cd6fa8d94dbc5fd44ac2c/842c7a142d2249f0c25e654a10e4fb10ac5ae2c7fa6cd6fa8d94dbc5fd44ac2c-json.log",
  "Name": "/my-test-container",
  "RestartCount": 0,
  "Driver": "overlayfs",
  "Platform": "linux",
  "AppArmorProfile": "",
  "SizeRw": 4096,
  "SizeRootFs": 87609344,
  "Mounts": [...],
  "Config": {...}
  },
  "NetworkSettings": null
}
```
*Description of changes:*

*Testing done:*



- [ ] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
