### PR TITLE
chore(ci): bump containerd [1.7.27, 2.0.4] matrix

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -78,7 +78,7 @@ jobs:
     needs: [build]
     strategy:
       matrix:
-        containerd: ["1.7.22", "2.0.0"]
+        containerd: ["1.7.27", "2.0.4"]
       fail-fast: false
     timeout-minutes: 10
     env:


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
This change bumps the containerd matrix for 1.7.26 and 2.0.2 containerd releases.

*Testing done:*
Green checks says it all


- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
