### PR TITLE
fix: Tag mockgen and stringer packages for gen-code make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,8 +77,8 @@ endif
 .PHONY:  gen-code
  gen-code: linux
 	rm -rf ./pkg/mocks
-	GOBIN=$(BIN) go install github.com/golang/mock/mockgen
-	GOBIN=$(BIN) go install golang.org/x/tools/cmd/stringer
+	GOBIN=$(BIN) go install github.com/golang/mock/mockgen@v1.6.0
+	GOBIN=$(BIN) go install golang.org/x/tools/cmd/stringer@v0.31.0
 	PATH=$(BIN):$(PATH) go generate ./...
 	PATH=$(BIN):$(PATH) mockgen --destination=./mocks/mocks_container/container.go -package=mocks_container github.com/containerd/containerd/v2/client Container
 	PATH=$(BIN):$(PATH) mockgen --destination=./mocks/mocks_container/process.go -package=mocks_container github.com/containerd/containerd/v2/client Process


### PR DESCRIPTION
Issue #, if available:

`mockgen` and `stringer` packages are installed via the make target, these packages when not tagged will default to the local directory for its dependent packages. `x/mod ` is one of those packages which was recently removed from the go.mod

tagging these packages would force the go runtime to install the package and its dependencies

*Description of changes:*

*Testing done:*



- [ ] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
