### PR TITLE
chore: update golang 1.23 for release automation runner

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ on:
       - '**.md'
   workflow_dispatch:
 env:
-  GO_VERSION: '1.23.0'
+  GO_VERSION: '1.23.7'
   GOLANGCI_LINT_VERSION: '1.60.3'
 jobs:
   git-secrets:

--- a/.github/workflows/release-automation.yaml
+++ b/.github/workflows/release-automation.yaml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
   workflow_call:
 env:
-  GO_VERSION: '1.22.7'
+  GO_VERSION: '1.23.7'
 permissions:
   contents: write
   deployments: write

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/runfinch/finch-daemon
 
-go 1.23.0
+go 1.23.7
 
 require (
 	github.com/containerd/cgroups/v3 v3.0.5


### PR DESCRIPTION
Issue #, if available:
Current release automation workflow is failing during the `make licenses` step.
Investigation has shown that the golang version in the runner is still 1.22.7 and similar issue reported upstream has pointed to golang update as the resolution.


- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
