### PR TITLE
feat: Add container top support

### DIFF
--- a/api/handlers/container/container.go
+++ b/api/handlers/container/container.go
@@ -37,6 +37,7 @@ type Service interface {
 	Kill(ctx context.Context, cid string, options ncTypes.ContainerKillOptions) error
 	Pause(ctx context.Context, cid string, options ncTypes.ContainerPauseOptions) error
 	Unpause(ctx context.Context, cid string, options ncTypes.ContainerUnpauseOptions) error
+	Top(ctx context.Context, cid string, options ncTypes.ContainerTopOptions) error
 }
 
 // RegisterHandlers register all the supported endpoints related to the container APIs.
@@ -63,6 +64,7 @@ func RegisterHandlers(r types.VersionedRouter, service Service, conf *config.Con
 	r.HandleFunc("/{id:.*}/kill", h.kill, http.MethodPost)
 	r.HandleFunc("/{id:.*}/pause", h.pause, http.MethodPost)
 	r.HandleFunc("/{id:.*}/unpause", h.unpause, http.MethodPost)
+	r.HandleFunc("/{id:.*}/top", h.top, http.MethodGet)
 }
 
 // newHandler creates the handler that serves all the container related APIs.

--- a/api/handlers/container/top.go
+++ b/api/handlers/container/top.go
@@ -1,0 +1,108 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package container
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/containerd/containerd/v2/pkg/namespaces"
+	ncTypes "github.com/containerd/nerdctl/v2/pkg/api/types"
+	"github.com/containerd/nerdctl/v2/pkg/cmd/container"
+	"github.com/gorilla/mux"
+
+	"github.com/runfinch/finch-daemon/api/response"
+	"github.com/runfinch/finch-daemon/pkg/errdefs"
+)
+
+func (h *handler) top(w http.ResponseWriter, r *http.Request) {
+	cid, ok := mux.Vars(r)["id"]
+	if !ok || cid == "" {
+		response.JSON(w, http.StatusBadRequest, response.NewErrorFromMsg("must specify a container ID"))
+		return
+	}
+
+	psArgs := r.URL.Query().Get("ps_args")
+	if psArgs == "" {
+		// Set default ps arguments if none provided
+		psArgs = "-ef" // or whatever default you want to use
+	}
+
+	ctx := namespaces.WithNamespace(r.Context(), h.Config.Namespace)
+
+	var buf bytes.Buffer
+
+	globalOpt := ncTypes.GlobalCommandOptions(*h.Config)
+	options := ncTypes.ContainerTopOptions{
+		GOptions: globalOpt,
+		Stdout:   &buf,
+		PsArgs:   psArgs,
+	}
+
+	fmt.Printf("calling nerdctl top with the following option : %s", options.PsArgs)
+	err := h.service.Top(ctx, cid, options)
+	if err != nil {
+		var code int
+		switch {
+		case errdefs.IsNotFound(err):
+			code = http.StatusNotFound
+		case errdefs.IsConflict(err):
+			code = http.StatusConflict
+		case strings.Contains(err.Error(), "unknown") || strings.Contains(err.Error(), "invalid"):
+			code = http.StatusBadRequest
+		default:
+			code = http.StatusInternalServerError
+		}
+		response.JSON(w, code, response.NewError(err))
+		return
+	}
+
+	// Parse the output
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	if len(lines) < 2 {
+		response.JSON(w, http.StatusInternalServerError, response.NewErrorFromMsg("invalid top output format"))
+		return
+	}
+
+	// Parse titles
+	titles := strings.Fields(lines[0])
+
+	// Find the CMD/COMMAND column index
+	cmdIndex := -1
+	for i, name := range titles {
+		if name == "CMD" || name == "COMMAND" || name == "ARGS" {
+			cmdIndex = i
+			break
+		}
+	}
+
+	// Parse processes
+	processes := make([][]string, 0, len(lines)-1)
+	for _, line := range lines[1:] {
+		if len(strings.TrimSpace(line)) > 0 {
+			fields := strings.Fields(line)
+			if len(fields) == 0 {
+				continue
+			}
+
+			if cmdIndex != -1 && len(fields) > cmdIndex {
+				process := make([]string, cmdIndex)
+				copy(process, fields[:cmdIndex])
+				process = append(process, strings.Join(fields[cmdIndex:], " "))
+				processes = append(processes, process)
+			} else {
+				processes = append(processes, fields)
+			}
+		}
+	}
+
+	resp := container.ContainerTopOKBody{
+		Processes: processes,
+		Titles:    titles,
+	}
+
+	response.JSON(w, http.StatusOK, resp)
+}

--- a/api/handlers/container/top_test.go
+++ b/api/handlers/container/top_test.go
@@ -46,6 +46,9 @@ var _ = Describe("Container Top API", func() {
 			Expect(err).Should(BeNil())
 			req = mux.SetURLVars(req, map[string]string{"id": "id1"})
 
+			// Mock logger call
+			logger.EXPECT().Infof("calling nerdctl top with the following option : %s", "-ef")
+
 			// Mock successful response with default ps output
 			defaultPsOutput := "UID PID PPID C STIME TTY TIME CMD\nroot 1 0 0 10:00 ? 00:00:00 sleep Infinity\n"
 			service.EXPECT().Top(gomock.Any(), "id1", gomock.Any()).DoAndReturn(
@@ -68,6 +71,9 @@ var _ = Describe("Container Top API", func() {
 			req, err := http.NewRequest(http.MethodGet, "/containers/id1/top?ps_args=-o pid,ppid,cmd", nil)
 			Expect(err).Should(BeNil())
 			req = mux.SetURLVars(req, map[string]string{"id": "id1"})
+
+			// Mock logger call
+			logger.EXPECT().Infof("calling nerdctl top with the following option : %s", "-o pid,ppid,cmd")
 
 			customPsOutput := "PID PPID CMD\n1 0 sleep Infinity\n"
 			service.EXPECT().Top(gomock.Any(), "id1", gomock.Any()).DoAndReturn(
@@ -101,6 +107,9 @@ var _ = Describe("Container Top API", func() {
 			Expect(err).Should(BeNil())
 			req = mux.SetURLVars(req, map[string]string{"id": "id1"})
 
+			// Mock logger call
+			logger.EXPECT().Infof("calling nerdctl top with the following option : %s", "-ef")
+
 			service.EXPECT().Top(gomock.Any(), "id1", gomock.Any()).Return(errdefs.NewNotFound(fmt.Errorf("not found")))
 
 			h.top(rr, req)
@@ -112,6 +121,9 @@ var _ = Describe("Container Top API", func() {
 			req, err := http.NewRequest(http.MethodGet, "/containers/id1/top", nil)
 			Expect(err).Should(BeNil())
 			req = mux.SetURLVars(req, map[string]string{"id": "id1"})
+
+			// Mock logger call
+			logger.EXPECT().Infof("calling nerdctl top with the following option : %s", "-ef")
 
 			service.EXPECT().Top(gomock.Any(), "id1", gomock.Any()).Return(errdefs.NewConflict(fmt.Errorf("conflict")))
 
@@ -125,6 +137,9 @@ var _ = Describe("Container Top API", func() {
 			Expect(err).Should(BeNil())
 			req = mux.SetURLVars(req, map[string]string{"id": "id1"})
 
+			// Mock logger call
+			logger.EXPECT().Infof("calling nerdctl top with the following option : %s", "--invalid")
+
 			service.EXPECT().Top(gomock.Any(), "id1", gomock.Any()).Return(fmt.Errorf("unknown argument --invalid"))
 
 			h.top(rr, req)
@@ -137,6 +152,9 @@ var _ = Describe("Container Top API", func() {
 			Expect(err).Should(BeNil())
 			req = mux.SetURLVars(req, map[string]string{"id": "id1"})
 
+			// Mock logger call
+			logger.EXPECT().Infof("calling nerdctl top with the following option : %s", "-ef")
+
 			service.EXPECT().Top(gomock.Any(), "id1", gomock.Any()).Return(fmt.Errorf("unexpected error"))
 
 			h.top(rr, req)
@@ -148,6 +166,9 @@ var _ = Describe("Container Top API", func() {
 			req, err := http.NewRequest(http.MethodGet, "/containers/id1/top", nil)
 			Expect(err).Should(BeNil())
 			req = mux.SetURLVars(req, map[string]string{"id": "id1"})
+
+			// Mock logger call
+			logger.EXPECT().Infof("calling nerdctl top with the following option : %s", "-ef")
 
 			service.EXPECT().Top(gomock.Any(), "id1", gomock.Any()).DoAndReturn(
 				func(ctx context.Context, cid string, opts ncTypes.ContainerTopOptions) error {

--- a/api/handlers/container/top_test.go
+++ b/api/handlers/container/top_test.go
@@ -1,0 +1,164 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package container
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+
+	ncTypes "github.com/containerd/nerdctl/v2/pkg/api/types"
+	"github.com/containerd/nerdctl/v2/pkg/config"
+	"github.com/gorilla/mux"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/runfinch/finch-daemon/pkg/errdefs"
+	"go.uber.org/mock/gomock"
+
+	"github.com/runfinch/finch-daemon/mocks/mocks_container"
+	"github.com/runfinch/finch-daemon/mocks/mocks_logger"
+)
+
+var _ = Describe("Container Top API", func() {
+	var (
+		mockCtrl *gomock.Controller
+		logger   *mocks_logger.Logger
+		service  *mocks_container.MockService
+		h        *handler
+		rr       *httptest.ResponseRecorder
+	)
+
+	BeforeEach(func() {
+		mockCtrl = gomock.NewController(GinkgoT())
+		defer mockCtrl.Finish()
+		logger = mocks_logger.NewLogger(mockCtrl)
+		service = mocks_container.NewMockService(mockCtrl)
+		c := config.Config{}
+		h = newHandler(service, &c, logger)
+		rr = httptest.NewRecorder()
+	})
+
+	Context("top handler", func() {
+		It("should return 200 OK with process list using default ps args", func() {
+			req, err := http.NewRequest(http.MethodGet, "/containers/id1/top", nil)
+			Expect(err).Should(BeNil())
+			req = mux.SetURLVars(req, map[string]string{"id": "id1"})
+
+			// Mock successful response with default ps output
+			defaultPsOutput := "UID PID PPID C STIME TTY TIME CMD\nroot 1 0 0 10:00 ? 00:00:00 sleep Infinity\n"
+			service.EXPECT().Top(gomock.Any(), "id1", gomock.Any()).DoAndReturn(
+				func(ctx context.Context, cid string, opts ncTypes.ContainerTopOptions) error {
+					Expect(opts.PsArgs).Should(Equal("-ef"))
+					_, err := opts.Stdout.Write([]byte(defaultPsOutput))
+					return err
+				})
+
+			h.top(rr, req)
+			expectedResponse := `{
+				"Titles": ["UID", "PID", "PPID", "C", "STIME", "TTY", "TIME", "CMD"],
+				"Processes": [["root", "1", "0", "0", "10:00", "?", "00:00:00", "sleep Infinity"]]
+			}`
+			Expect(rr.Body).Should(MatchJSON(expectedResponse))
+			Expect(rr).Should(HaveHTTPStatus(http.StatusOK))
+		})
+
+		It("should return 200 OK with custom ps args", func() {
+			req, err := http.NewRequest(http.MethodGet, "/containers/id1/top?ps_args=-o pid,ppid,cmd", nil)
+			Expect(err).Should(BeNil())
+			req = mux.SetURLVars(req, map[string]string{"id": "id1"})
+
+			customPsOutput := "PID PPID CMD\n1 0 sleep Infinity\n"
+			service.EXPECT().Top(gomock.Any(), "id1", gomock.Any()).DoAndReturn(
+				func(ctx context.Context, cid string, opts ncTypes.ContainerTopOptions) error {
+					Expect(opts.PsArgs).Should(Equal("-o pid,ppid,cmd"))
+					_, err := opts.Stdout.Write([]byte(customPsOutput))
+					return err
+				})
+
+			h.top(rr, req)
+			expectedResponse := `{
+				"Titles": ["PID", "PPID", "CMD"],
+				"Processes": [["1", "0", "sleep Infinity"]]
+			}`
+			Expect(rr.Body).Should(MatchJSON(expectedResponse))
+			Expect(rr).Should(HaveHTTPStatus(http.StatusOK))
+		})
+
+		It("should return 400 when container ID is missing", func() {
+			req, err := http.NewRequest(http.MethodGet, "/containers//top", nil)
+			Expect(err).Should(BeNil())
+			req = mux.SetURLVars(req, map[string]string{"id": ""})
+
+			h.top(rr, req)
+			Expect(rr.Body).Should(MatchJSON(`{"message": "must specify a container ID"}`))
+			Expect(rr).Should(HaveHTTPStatus(http.StatusBadRequest))
+		})
+
+		It("should return 404 when service returns a not found error", func() {
+			req, err := http.NewRequest(http.MethodGet, "/containers/id1/top", nil)
+			Expect(err).Should(BeNil())
+			req = mux.SetURLVars(req, map[string]string{"id": "id1"})
+
+			service.EXPECT().Top(gomock.Any(), "id1", gomock.Any()).Return(errdefs.NewNotFound(fmt.Errorf("not found")))
+
+			h.top(rr, req)
+			Expect(rr.Body).Should(MatchJSON(`{"message": "not found"}`))
+			Expect(rr).Should(HaveHTTPStatus(http.StatusNotFound))
+		})
+
+		It("should return 409 when service returns a conflict error", func() {
+			req, err := http.NewRequest(http.MethodGet, "/containers/id1/top", nil)
+			Expect(err).Should(BeNil())
+			req = mux.SetURLVars(req, map[string]string{"id": "id1"})
+
+			service.EXPECT().Top(gomock.Any(), "id1", gomock.Any()).Return(errdefs.NewConflict(fmt.Errorf("conflict")))
+
+			h.top(rr, req)
+			Expect(rr.Body).Should(MatchJSON(`{"message": "conflict"}`))
+			Expect(rr).Should(HaveHTTPStatus(http.StatusConflict))
+		})
+
+		It("should return 400 when service returns an invalid argument error", func() {
+			req, err := http.NewRequest(http.MethodGet, "/containers/id1/top?ps_args=--invalid", nil)
+			Expect(err).Should(BeNil())
+			req = mux.SetURLVars(req, map[string]string{"id": "id1"})
+
+			service.EXPECT().Top(gomock.Any(), "id1", gomock.Any()).Return(fmt.Errorf("unknown argument --invalid"))
+
+			h.top(rr, req)
+			Expect(rr.Body).Should(MatchJSON(`{"message": "unknown argument --invalid"}`))
+			Expect(rr).Should(HaveHTTPStatus(http.StatusBadRequest))
+		})
+
+		It("should return 500 when service returns an internal error", func() {
+			req, err := http.NewRequest(http.MethodGet, "/containers/id1/top", nil)
+			Expect(err).Should(BeNil())
+			req = mux.SetURLVars(req, map[string]string{"id": "id1"})
+
+			service.EXPECT().Top(gomock.Any(), "id1", gomock.Any()).Return(fmt.Errorf("unexpected error"))
+
+			h.top(rr, req)
+			Expect(rr.Body).Should(MatchJSON(`{"message": "unexpected error"}`))
+			Expect(rr).Should(HaveHTTPStatus(http.StatusInternalServerError))
+		})
+
+		It("should return 500 when output format is invalid", func() {
+			req, err := http.NewRequest(http.MethodGet, "/containers/id1/top", nil)
+			Expect(err).Should(BeNil())
+			req = mux.SetURLVars(req, map[string]string{"id": "id1"})
+
+			service.EXPECT().Top(gomock.Any(), "id1", gomock.Any()).DoAndReturn(
+				func(ctx context.Context, cid string, opts ncTypes.ContainerTopOptions) error {
+					// Write invalid output format
+					_, err := opts.Stdout.Write([]byte("invalid output"))
+					return err
+				})
+
+			h.top(rr, req)
+			Expect(rr.Body).Should(MatchJSON(`{"message": "invalid top output format"}`))
+			Expect(rr).Should(HaveHTTPStatus(http.StatusInternalServerError))
+		})
+	})
+})

--- a/e2e/tests/container_top.go
+++ b/e2e/tests/container_top.go
@@ -1,0 +1,134 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package tests
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/runfinch/common-tests/command"
+	"github.com/runfinch/common-tests/option"
+
+	"github.com/runfinch/finch-daemon/e2e/client"
+)
+
+type ContainerTopResponse struct {
+	Titles    []string   `json:"Titles"`
+	Processes [][]string `json:"Processes"`
+}
+
+func ContainerTop(opt *option.Option) {
+	Describe("Get list of processes running inside a Container", func() {
+		var (
+			uClient *http.Client
+			version string
+		)
+		BeforeEach(func() {
+			uClient = client.NewClient(GetDockerHostUrl())
+			version = GetDockerApiVersion()
+		})
+		AfterEach(func() {
+			command.RemoveAll(opt)
+		})
+
+		It("should return process list with default ps args", func() {
+			command.StdoutStr(opt, "run", "-d", "--name", testContainerName, defaultImage, "sleep", "infinity")
+
+			res, err := uClient.Get(client.ConvertToFinchUrl(version, fmt.Sprintf("/containers/%s/top", testContainerName)))
+			Expect(err).Should(BeNil())
+			Expect(res.StatusCode).Should(Equal(http.StatusOK))
+
+			body, err := io.ReadAll(res.Body)
+			Expect(err).Should(BeNil())
+			defer res.Body.Close()
+
+			var topResponse ContainerTopResponse
+			err = json.Unmarshal(body, &topResponse)
+			Expect(err).Should(BeNil())
+
+			// Validate the response structure
+			Expect(topResponse.Titles).ShouldNot(BeEmpty())
+			Expect(topResponse.Processes).ShouldNot(BeEmpty())
+
+			// Validate that the sleep process is present
+			foundSleepProcess := false
+			for _, process := range topResponse.Processes {
+				processCmd := strings.Join(process, " ")
+				if strings.Contains(processCmd, "sleep infinity") {
+					foundSleepProcess = true
+					break
+				}
+			}
+			Expect(foundSleepProcess).Should(BeTrue())
+		})
+
+		It("should return process list with custom ps args", func() {
+			command.StdoutStr(opt, "run", "-d", "--name", testContainerName, defaultImage, "sleep", "infinity")
+
+			// Call the top API with custom ps args that produce a specific format
+			// Using "-o pid,comm" which will return just PID and command name columns
+			customArgs := "-o%20pid,comm"
+			url := client.ConvertToFinchUrl(version, fmt.Sprintf("/containers/%s/top?ps_args=%s", testContainerName, customArgs))
+
+			res, err := uClient.Get(url)
+			Expect(err).Should(BeNil())
+
+			// Parse the response
+			body, err := io.ReadAll(res.Body)
+			Expect(err).Should(BeNil())
+			defer res.Body.Close()
+
+			var topResponse ContainerTopResponse
+			err = json.Unmarshal(body, &topResponse)
+			Expect(err).Should(BeNil())
+
+			// Validate the response structure has exactly the columns we requested
+			Expect(topResponse.Titles).Should(HaveLen(2))
+			Expect(topResponse.Titles).Should(ConsistOf("PID", "COMMAND"))
+			Expect(topResponse.Processes).ShouldNot(BeEmpty())
+
+			// Validate that each process entry has exactly 2 fields
+			for _, process := range topResponse.Processes {
+				Expect(process).Should(HaveLen(2))
+			}
+		})
+
+		It("should return 404 for non-existent container", func() {
+			// Call the top API with a non-existent container ID
+			res, err := uClient.Get(client.ConvertToFinchUrl(version, "/containers/non-existent-container/top"))
+			Expect(err).Should(BeNil())
+			Expect(res.StatusCode).Should(Equal(http.StatusNotFound))
+
+			// Parse the error response
+			body, err := io.ReadAll(res.Body)
+			Expect(err).Should(BeNil())
+			defer res.Body.Close()
+
+			// Verify error message contains "no such container"
+			Expect(string(body)).Should(ContainSubstring("no such container"))
+		})
+
+		It("should return 400 for invalid ps args", func() {
+			command.StdoutStr(opt, "run", "-d", "--name", testContainerName, defaultImage, "sleep", "infinity")
+
+			// Call the top API with invalid ps args
+			invalidArgs := "--invalid-arg"
+			res, err := uClient.Get(client.ConvertToFinchUrl(version, fmt.Sprintf("/containers/%s/top?ps_args=%s", testContainerName, invalidArgs)))
+			Expect(err).Should(BeNil())
+			Expect(res.StatusCode).Should(Equal(http.StatusBadRequest))
+		})
+
+		It("should return 405 for empty container ID", func() {
+			// Call the top API with an empty container ID
+			res, err := uClient.Get(client.ConvertToFinchUrl(version, "/containers//top"))
+			Expect(err).Should(BeNil())
+			Expect(res.StatusCode).Should(Equal(http.StatusMethodNotAllowed))
+		})
+	})
+}

--- a/internal/backend/container.go
+++ b/internal/backend/container.go
@@ -37,6 +37,7 @@ type NerdctlContainerSvc interface {
 	ContainerWait(ctx context.Context, cid string, options types.ContainerWaitOptions) error
 	PauseContainer(ctx context.Context, cid string, options types.ContainerPauseOptions) error
 	UnpauseContainer(ctx context.Context, cid string, options types.ContainerUnpauseOptions) error
+	ContainerTop(ctx context.Context, cid string, options types.ContainerTopOptions) error
 
 	// Mocked functions for container attach
 	GetDataStore() (string, error)
@@ -133,6 +134,10 @@ func (w *NerdctlWrapper) PauseContainer(ctx context.Context, cid string, options
 
 func (w *NerdctlWrapper) UnpauseContainer(ctx context.Context, cid string, options types.ContainerUnpauseOptions) error {
 	return container.Unpause(ctx, w.clientWrapper.client, []string{cid}, options)
+}
+
+func (w *NerdctlWrapper) ContainerTop(ctx context.Context, cid string, options types.ContainerTopOptions) error {
+	return container.Top(ctx, w.clientWrapper.client, []string{cid}, options)
 }
 
 func (w *NerdctlWrapper) GetNerdctlExe() (string, error) {

--- a/internal/service/container/top.go
+++ b/internal/service/container/top.go
@@ -1,0 +1,30 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package container
+
+import (
+	"context"
+
+	cerrdefs "github.com/containerd/errdefs"
+	ncTypes "github.com/containerd/nerdctl/v2/pkg/api/types"
+
+	"github.com/runfinch/finch-daemon/pkg/errdefs"
+)
+
+func (s *service) Top(ctx context.Context, cid string, options ncTypes.ContainerTopOptions) error {
+	_, err := s.getContainer(ctx, cid)
+	if err != nil {
+		if cerrdefs.IsNotFound(err) {
+			return errdefs.NewNotFound(err)
+		}
+		return err
+	}
+
+	err = s.nctlContainerSvc.ContainerTop(ctx, cid, options)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/internal/service/container/top_test.go
+++ b/internal/service/container/top_test.go
@@ -1,0 +1,102 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package container
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"go.uber.org/mock/gomock"
+
+	containerd "github.com/containerd/containerd/v2/client"
+	cerrdefs "github.com/containerd/errdefs"
+	ncTypes "github.com/containerd/nerdctl/v2/pkg/api/types"
+	"github.com/runfinch/finch-daemon/mocks/mocks_backend"
+	"github.com/runfinch/finch-daemon/mocks/mocks_container"
+	"github.com/runfinch/finch-daemon/mocks/mocks_logger"
+	"github.com/runfinch/finch-daemon/pkg/errdefs"
+)
+
+var _ = Describe("Container Top API", func() {
+	var (
+		ctx            context.Context
+		mockCtrl       *gomock.Controller
+		logger         *mocks_logger.Logger
+		cdClient       *mocks_backend.MockContainerdClient
+		ncContainerSvc *mocks_backend.MockNerdctlContainerSvc
+		ncNetworkSvc   *mocks_backend.MockNerdctlNetworkSvc
+		svc            *service
+		cid            string
+		topOptions     ncTypes.ContainerTopOptions
+		con            *mocks_container.MockContainer
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		mockCtrl = gomock.NewController(GinkgoT())
+		logger = mocks_logger.NewLogger(mockCtrl)
+		cdClient = mocks_backend.NewMockContainerdClient(mockCtrl)
+		ncContainerSvc = mocks_backend.NewMockNerdctlContainerSvc(mockCtrl)
+		ncNetworkSvc = mocks_backend.NewMockNerdctlNetworkSvc(mockCtrl)
+
+		cid = "test-container-id"
+		topOptions = ncTypes.ContainerTopOptions{
+			PsArgs: "-ef",
+		}
+		con = mocks_container.NewMockContainer(mockCtrl)
+		con.EXPECT().ID().Return(cid).AnyTimes()
+
+		svc = &service{
+			client:           cdClient,
+			nctlContainerSvc: mockNerdctlService{ncContainerSvc, ncNetworkSvc},
+			logger:           logger,
+		}
+	})
+
+	AfterEach(func() {
+		mockCtrl.Finish()
+	})
+
+	Context("Top API", func() {
+		It("should successfully get top processes of a container", func() {
+			cdClient.EXPECT().SearchContainer(gomock.Any(), cid).Return(
+				[]containerd.Container{con}, nil)
+			ncContainerSvc.EXPECT().ContainerTop(ctx, cid, topOptions).Return(nil)
+
+			err := svc.Top(ctx, cid, topOptions)
+			Expect(err).Should(BeNil())
+		})
+
+		It("should return NotFound error if container is not found", func() {
+			mockErr := cerrdefs.ErrNotFound.WithMessage(fmt.Sprintf("no such container: %s", cid))
+			cdClient.EXPECT().SearchContainer(gomock.Any(), cid).Return(nil, mockErr)
+			logger.EXPECT().Errorf(gomock.Any(), gomock.Any(), gomock.Any())
+
+			err := svc.Top(ctx, cid, topOptions)
+			Expect(err.Error()).Should(Equal(errdefs.NewNotFound(fmt.Errorf("no such container: %s", cid)).Error()))
+		})
+
+		It("should return error from ContainerTop if it fails", func() {
+			cdClient.EXPECT().SearchContainer(gomock.Any(), cid).Return(
+				[]containerd.Container{con}, nil)
+			mockErr := errors.New("failed to get container processes")
+			ncContainerSvc.EXPECT().ContainerTop(ctx, cid, topOptions).Return(mockErr)
+
+			err := svc.Top(ctx, cid, topOptions)
+			Expect(err).Should(Equal(mockErr))
+		})
+
+		It("should return error if SearchContainer fails with non-NotFound error", func() {
+			mockErr := errors.New("failed to search container")
+			cdClient.EXPECT().SearchContainer(gomock.Any(), cid).Return(nil, mockErr)
+			logger.EXPECT().Errorf(gomock.Any(), gomock.Any(), gomock.Any())
+
+			err := svc.Top(ctx, cid, topOptions)
+			Expect(err).Should(Equal(mockErr))
+		})
+	})
+})

--- a/mocks/mocks_backend/nerdctlcontainersvc.go
+++ b/mocks/mocks_backend/nerdctlcontainersvc.go
@@ -49,6 +49,20 @@ func (m *MockNerdctlContainerSvc) EXPECT() *MockNerdctlContainerSvcMockRecorder 
 	return m.recorder
 }
 
+// ContainerTop mocks base method.
+func (m *MockNerdctlContainerSvc) ContainerTop(ctx context.Context, cid string, options types.ContainerTopOptions) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ContainerTop", ctx, cid, options)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ContainerTop indicates an expected call of ContainerTop.
+func (mr *MockNerdctlContainerSvcMockRecorder) ContainerTop(ctx, cid, options any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContainerTop", reflect.TypeOf((*MockNerdctlContainerSvc)(nil).ContainerTop), ctx, cid, options)
+}
+
 // ContainerWait mocks base method.
 func (m *MockNerdctlContainerSvc) ContainerWait(ctx context.Context, cid string, options types.ContainerWaitOptions) error {
 	m.ctrl.T.Helper()

--- a/mocks/mocks_container/containersvc.go
+++ b/mocks/mocks_container/containersvc.go
@@ -274,6 +274,20 @@ func (mr *MockServiceMockRecorder) Stop(ctx, cid, option any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stop", reflect.TypeOf((*MockService)(nil).Stop), ctx, cid, option)
 }
 
+// Top mocks base method.
+func (m *MockService) Top(ctx context.Context, cid string, options types.ContainerTopOptions) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Top", ctx, cid, options)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Top indicates an expected call of Top.
+func (mr *MockServiceMockRecorder) Top(ctx, cid, options any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Top", reflect.TypeOf((*MockService)(nil).Top), ctx, cid, options)
+}
+
 // Unpause mocks base method.
 func (m *MockService) Unpause(ctx context.Context, cid string, options types.ContainerUnpauseOptions) error {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
Issue #, if available:

This PR adds Support for [Container top API](https://docs.docker.com/reference/api/engine/version/v1.43/#tag/Container/operation/ContainerTop) - The API lists the running processes inside a container

- ~needs https://github.com/containerd/nerdctl/pull/4063~ (merged)
- unit and e2e tests added

*Description of changes:*
- adds a new API (GET) `container/top`

Output format
```
{
  "Processes": [
    [
      "root",
      "25508",
      "25472",
      "0",
      "18:55",
      "?",
      "00:00:00",
      "sleep Infinity"
    ]
  ],
  "Titles": [
    "UID",
    "PID",
    "PPID",
    "C",
    "STIME",
    "TTY",
    "TIME",
    "CMD"
  ]
}
```



- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
