### PR TITLE
test: improve date parsing robustness

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,7 @@ test-e2e: linux
 	DOCKER_HOST="unix:///run/finch.sock" \
 	DOCKER_API_VERSION="v1.41" \
 	TEST_E2E=1 \
-	go test ./e2e -test.v -ginkgo.v -ginkgo.randomize-all
+	$(GINKGO) $(GFLAGS) ./e2e/...
 
 .PHONY: licenses
 licenses:

--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,7 @@ test-e2e: linux
 	DOCKER_HOST="unix:///run/finch.sock" \
 	DOCKER_API_VERSION="v1.41" \
 	TEST_E2E=1 \
-	$(GINKGO) $(GFLAGS) ./e2e/...
+	go test ./e2e -test.v -ginkgo.v -ginkgo.randomize-all
 
 .PHONY: licenses
 licenses:

--- a/e2e/tests/container_restart.go
+++ b/e2e/tests/container_restart.go
@@ -39,7 +39,7 @@ func ContainerRestart(opt *option.Option) {
 			command.RemoveAll(opt)
 		})
 
-		FIt("should start and restart the container", func() {
+		It("should start and restart the container", func() {
 			containerShouldBeRunning(opt, testContainerName)
 
 			// use location to ensure all times are UTC since

--- a/e2e/tests/container_restart.go
+++ b/e2e/tests/container_restart.go
@@ -56,7 +56,9 @@ func ContainerRestart(opt *option.Option) {
 			opts := "?stdout=1" +
 				"&stderr=0" +
 				"&follow=0" +
-				"&tail=0"
+				"&tail=0" +
+				"&since=0" +
+				"&tail=all"
 			res, err = uClient.Get(client.ConvertToFinchUrl(version, logsRelativeUrl+opts))
 			Expect(err).Should(BeNil())
 			body, err := io.ReadAll(res.Body)
@@ -68,7 +70,7 @@ func ContainerRestart(opt *option.Option) {
 				return !unicode.IsGraphic(r) || unicode.IsSpace(r)
 			})
 
-			fmt.Printf("\nbody: %s\ndateStr: %s\n", string(body), dateStr)
+			fmt.Printf("\nbefore: %s\nbody: %s\ndateStr: %s\n", before, string(body), dateStr)
 
 			date, err := time.ParseInLocation(time.UnixDate, dateStr, lo)
 			Expect(err).Should(BeNil())

--- a/e2e/tests/container_restart.go
+++ b/e2e/tests/container_restart.go
@@ -39,7 +39,7 @@ func ContainerRestart(opt *option.Option) {
 			command.RemoveAll(opt)
 		})
 
-		It("should start and restart the container", func() {
+		FIt("should start and restart the container", func() {
 			containerShouldBeRunning(opt, testContainerName)
 
 			// use location to ensure all times are UTC since
@@ -67,6 +67,9 @@ func ContainerRestart(opt *option.Option) {
 			dateStr := strings.TrimFunc(strings.Split(string(body), "\n")[1], func(r rune) bool {
 				return !unicode.IsGraphic(r) || unicode.IsSpace(r)
 			})
+
+			fmt.Printf("\nbody: %s\ndateStr: %s\n", string(body), dateStr)
+
 			date, err := time.ParseInLocation(time.UnixDate, dateStr, lo)
 			Expect(err).Should(BeNil())
 			Expect(before.Before(date)).Should(BeTrue())

--- a/e2e/tests/container_restart.go
+++ b/e2e/tests/container_restart.go
@@ -56,9 +56,7 @@ func ContainerRestart(opt *option.Option) {
 			opts := "?stdout=1" +
 				"&stderr=0" +
 				"&follow=0" +
-				"&tail=0" +
-				"&since=0" +
-				"&tail=all"
+				"&tail=0"
 			res, err = uClient.Get(client.ConvertToFinchUrl(version, logsRelativeUrl+opts))
 			Expect(err).Should(BeNil())
 			body, err := io.ReadAll(res.Body)
@@ -69,9 +67,6 @@ func ContainerRestart(opt *option.Option) {
 			dateStr := strings.TrimFunc(strings.Split(string(body), "\n")[1], func(r rune) bool {
 				return !unicode.IsGraphic(r) || unicode.IsSpace(r)
 			})
-
-			fmt.Printf("\nbefore: %s\nbody: %s\ndateStr: %s\n", before, string(body), dateStr)
-
 			date, err := time.ParseInLocation(time.UnixDate, dateStr, lo)
 			Expect(err).Should(BeNil())
 			Expect(before.Before(date)).Should(BeTrue())

--- a/setup-test-env.sh
+++ b/setup-test-env.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 # Set versions
-RUNC_VERSION=1.1.14
-NERDCTL_VERSION=2.0.0
-BUILDKIT_VERSION=0.15.2
+RUNC_VERSION=1.2.4
+NERDCTL_VERSION=2.0.3
+BUILDKIT_VERSION=0.18.1
 CNI_VERSION=1.6.2
 
 apt update && apt install -y make gcc linux-libc-dev libseccomp-dev pkg-config git


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
As seen in these error logs where the tests are being run from a macOS host system, there are issues which cause date parsing to not work uniformly across platforms. These changes make the way we're extracting the tests more readable and consistent in such scenarios, without breaking the existing functionality on Linux

Example test failure (source, [will expire](https://github.com/runfinch/finch/actions/runs/14136677910/job/39609957869?pr=1181)):
```
Finch Daemon Functional test restart a container should start and restart the container
/Users/ec2-user/ar/_work/finch/finch/deps/finch-core/src/finch-daemon/e2e/tests/container_restart.go:40
  localhost:56438/alpine:latest:                                                    resolved       |++++++++++++++++++++++++++++++++++++++| 
  index-sha256:ea1f182aa4369bea8b92cefe1b783d3feff1cdace3bcf2a016972ae1e08460d4:    done           |++++++++++++++++++++++++++++++++++++++| 
  manifest-sha256:757d680068d77be46fd1ea20fb21db16f150468c5e7079a08a2e4705aec096ac: done           |++++++++++++++++++++++++++++++++++++++| 
  config-sha256:8d591b0b7dea080ea3be9e12ae563eebf9869168ffced1cb25b2470a3d9fe15e:   done           |++++++++++++++++++++++++++++++++++++++| 
  elapsed: 0.1 s                                                                    total:   0.0 B (0.0 B/s)                                         
  09d75e2eba746e5cbacb98d049b9bc0cb05d59c88cc916b0cdc541c7968607ca
  09d75e2eba74
  [FAILED] in [It] - /Users/ec2-user/ar/_work/finch/finch/deps/finch-core/src/finch-daemon/e2e/tests/container_restart.go:62 @ 03/28/25 19:46:22.59
  09d75e2eba746e5cbacb98d049b9bc0cb05d59c88cc916b0cdc541c7968607ca
  d4222309f422563c94e73bce61626545169ab4cc8217e1d810386fd5e4ab0fd4
  09d75e2eba746e5cbacb98d049b9bc0cb05d59c88cc916b0cdc541c7968607ca
  ea1f182aa436
  a3d8aaa63ed8
  Untagged: localhost:56438/alpine:latest@sha256:ea1f182aa4369bea8b92cefe1b783d3feff1cdace3bcf2a016972ae1e08460d4
  Deleted: sha256:a16e98724c05975ee8c40d8fe389c3481373d34ab20a1cf52ea2accc43f71f4c
  public.ecr.aws/docker/library/registry:latest
  No images to be removed
  633823d733aaacd7f7788c9e53d47bc1f80d6ba52f07094903a380285fcbd8a2
  bridge
  host
  none
  No networks to be removed
• [FAILED] [11.634 seconds]
Finch Daemon Functional test restart a container [It] should start and restart the container
/Users/ec2-user/ar/_work/finch/finch/deps/finch-core/src/finch-daemon/e2e/tests/container_restart.go:40

  [FAILED] Expected
      <bool>: false
  to be true
```

*Testing done:*



- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
