### PR TITLE
chore: update golang to 1.23.8 for release automation runner

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ on:
       - '**.md'
   workflow_dispatch:
 env:
-  GO_VERSION: '1.23.7'
+  GO_VERSION: '1.23.8'
   GOLANGCI_LINT_VERSION: '1.60.3'
 jobs:
   git-secrets:

--- a/.github/workflows/release-automation.yaml
+++ b/.github/workflows/release-automation.yaml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
   workflow_call:
 env:
-  GO_VERSION: '1.23.7'
+  GO_VERSION: '1.23.8'
 permissions:
   contents: write
   deployments: write

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/runfinch/finch-daemon
 
-go 1.23.7
+go 1.23.8
 
 require (
 	github.com/containerd/cgroups/v3 v3.0.5


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
Update to latest go 1.23 version. Remediates [GO-2025-3563](https://pkg.go.dev/vuln/GO-2025-3563)

*Testing done:*



- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
