### PR TITLE
test(fix): don't override function variable

### DIFF
--- a/e2e/util/option_wrapper.go
+++ b/e2e/util/option_wrapper.go
@@ -17,7 +17,6 @@ type NewOpt func(subject []string, modifiers ...option.Modifier) (*option.Option
 // not the same as the system running the tests, like inside a SSH shell.
 func WrappedOption(prefix []string, wModifiers ...option.Modifier) NewOpt {
 	return func(subject []string, modifiers ...option.Modifier) (*option.Option, error) {
-		prefix = append(prefix, subject...)
-		return option.New(prefix, append(wModifiers, modifiers...)...)
+		return option.New(append(prefix, subject...), append(wModifiers, modifiers...)...)
 	}
 }


### PR DESCRIPTION
Issue #, if available: #223

## Description of changes
Fix for issue described here: https://github.com/runfinch/finch-daemon/issues/223. Thanks @chews93319 for the extra pair of eyes and deep dive, I couldn't see this issue at first from being "too close" to the code. I'm guessing I originally wrote the code the way I did because of the standard go idiom of reassigning back to the appended variable. In this case, that's wrong.

The reason this manifests as flakes is totally down to go/Ginkgo test parallelism and ordering. Whenever the "failure" test runs after the "success" test, the tests will pass because the failure test is still failing, just not for the right reason. There might be other cases which cause state to reset between parallel tests, but that's the most obvious condition.

## Testing done
- Recreated the issue locally. This is the hardest part (and the part most aided by the debugging on #223), since we only observed these failures as flakes when running on https://github.com/runfinch/finch/pull/1181.
  1. Modify `e2e/tests/network_create.go` to be focused (`Describe` -> `FDescribe`)
  2. Make the test run serially by adding `Serial` to the `FDescribe` call as a new argument before the callback
  3. Remove/comment all tests except the two which use pOpt
  4. Reorder the tests so that the failure case comes first (otherwise, the failure case will still fail, but for the wrong reason)
- Verify that the fix actually fixes the issue, i.e. the `prefix` added to the `pOpt` doesn't get repeated


- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
