### PR TITLE
feat: Add cgroupnsmode option

### DIFF
--- a/api/handlers/container/create_test.go
+++ b/api/handlers/container/create_test.go
@@ -974,6 +974,42 @@ var _ = Describe("Container Create API ", func() {
 			Expect(rr.Body).Should(MatchJSON(jsonResponse))
 		})
 
+		It("should set CgroupnsMode option", func() {
+			body := []byte(`{
+				"Image": "test-image",
+				"HostConfig": {
+					"CgroupnsMode": "host"
+				}
+			}`)
+			req, _ := http.NewRequest(http.MethodPost, "/containers/create", bytes.NewReader(body))
+
+			// expected create options
+			createOpt.Cgroupns = "host"
+
+			service.EXPECT().Create(gomock.Any(), "test-image", nil, equalTo(createOpt), equalTo(netOpt)).Return(
+				cid, nil)
+
+			// handler should return success message with 201 status code.
+			h.create(rr, req)
+			Expect(rr).Should(HaveHTTPStatus(http.StatusCreated))
+			Expect(rr.Body).Should(MatchJSON(jsonResponse))
+		})
+
+		It("should reject invalid CgroupnsMode values", func() {
+			body := []byte(`{
+				"Image": "test-image",
+				"HostConfig": {
+					"CgroupnsMode": "invalid"
+				}
+			}`)
+			req, _ := http.NewRequest(http.MethodPost, "/containers/create", bytes.NewReader(body))
+
+			// handler should return bad request with error message
+			h.create(rr, req)
+			Expect(rr).Should(HaveHTTPStatus(http.StatusBadRequest))
+			Expect(rr.Body.String()).Should(ContainSubstring("invalid cgroup namespace mode"))
+		})
+
 		Context("translate port mappings", func() {
 			It("should return empty if port mappings is nil", func() {
 				Expect(translatePortMappings(nil)).Should(BeEmpty())

--- a/api/types/container_types.go
+++ b/api/types/container_types.go
@@ -72,15 +72,15 @@ type ContainerHostConfig struct {
 	Annotations map[string]string `json:",omitempty"` // Arbitrary non-identifying metadata attached to container and provided to the runtime
 
 	// Applicable to UNIX platforms
-	CapAdd  []string // List of kernel capabilities to add to the container
-	CapDrop []string // List of kernel capabilities to remove from the container
-	// TODO: CgroupnsMode CgroupnsMode // Cgroup namespace mode to use for the container
-	DNS        []string `json:"Dns"`        // List of DNS server to lookup
-	DNSOptions []string `json:"DnsOptions"` // List of DNSOption to look for
-	DNSSearch  []string `json:"DnsSearch"`  // List of DNSSearch to look for
-	ExtraHosts []string // List of extra hosts
-	GroupAdd   []string // List of additional groups that the container process will run as
-	IpcMode    string   // IPC namespace to use for the container
+	CapAdd       []string     // List of kernel capabilities to add to the container
+	CapDrop      []string     // List of kernel capabilities to remove from the container
+	CgroupnsMode CgroupnsMode // Cgroup namespace mode to use for the container
+	DNS          []string     `json:"Dns"`        // List of DNS server to lookup
+	DNSOptions   []string     `json:"DnsOptions"` // List of DNSOption to look for
+	DNSSearch    []string     `json:"DnsSearch"`  // List of DNSSearch to look for
+	ExtraHosts   []string     // List of extra hosts
+	GroupAdd     []string     // List of additional groups that the container process will run as
+	IpcMode      string       // IPC namespace to use for the container
 	// TODO: Cgroup          CgroupSpec        // Cgroup to use for the container
 	// TODO: Links           []string          // List of links (in the name:alias form)
 	OomKillDisable bool // specifies whether to disable OOM Killer
@@ -271,3 +271,18 @@ type StatsJSON struct {
 }
 
 type Ulimit = units.Ulimit
+
+// CgroupnsMode represents the cgroup namespace mode of the container.
+type CgroupnsMode string
+
+// cgroup namespace modes for containers.
+const (
+	CgroupnsModeEmpty   CgroupnsMode = ""
+	CgroupnsModePrivate CgroupnsMode = "private"
+	CgroupnsModeHost    CgroupnsMode = "host"
+)
+
+// Valid indicates whether the cgroup namespace mode is valid.
+func (c CgroupnsMode) Valid() bool {
+	return c == CgroupnsModePrivate || c == CgroupnsModeHost
+}


### PR DESCRIPTION
Issue #, if available:

Adds cgroupsns option to container create. this allows users to control the cgroup namespace a container uses

*Description of changes:*
- added option
- unit tests 
- integration tests

*Testing done:*



- [X] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
