### PR TITLE
ci: update release github actions runners to ubuntu-22.04

### DIFF
--- a/.github/workflows/release-automation.yaml
+++ b/.github/workflows/release-automation.yaml
@@ -22,7 +22,7 @@ jobs:
         uses: "WyriHaximus/github-action-get-previous-tag@04e8485ecb6487243907e330d522ff60f02283ce" # v1.4.0
   generate-artifacts:
     needs: get-latest-tag
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       # Set during setup.
       RELEASE_TAG: ${{ needs.get-latest-tag.outputs.tag }}


### PR DESCRIPTION
Issue #, if available:
Release automation currently fails due to GitHub Actions retirement of Ubuntu-20 runners.

*Description of changes:*
This change updates the release automation runners to Ubuntu-22.04

*Testing done:*
N/A


- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
