### PR TITLE
fix: skip blkio test in vm

### DIFF
--- a/e2e/tests/container_create.go
+++ b/e2e/tests/container_create.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -797,6 +798,11 @@ func ContainerCreate(opt *option.Option, pOpt util.NewOpt) {
 		})
 
 		It("should create container with specified blkio settings options", func() {
+			// Skip if not running on Linux
+			if runtime.GOOS != "linux" {
+				Skip("Blkio settings are only supported on Linux")
+			}
+
 			// Create dummy device paths
 			dummyDev1 := "/dev/dummy-zero1"
 			dummyDev2 := "/dev/dummy-zero2"


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
skipping blkio test on mac/windows finch vm setups

*Testing done:*
```
finch Daemon Functional test create container [It] should create container with specified blkio settings options
/Users/shubhum/Documents/WorkPackages/finch-daemon/e2e/tests/container_create.go:800

  [SKIPPED] Blkio settings are only supported on Linux
```

- [ ] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
