### PR TITLE
chore: update golangci_lint version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ on:
   workflow_dispatch:
 env:
   GO_VERSION: '1.23.8'
-  GOLANGCI_LINT_VERSION: '1.60.3'
+  GOLANGCI_LINT_VERSION: '1.64.8'
 jobs:
   git-secrets:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Issue #, if available:

We are seeing multiple lint failures in the CI as github rolls out newer version of its [ubuntu-24.04 images](https://github.com/actions/runner-images?tab=readme-ov-file#available-images)

Updating the GOLANGCI_LINT_VERSION to the latest 1.64.8 seems to be working. (Verified that the runner image version is Version: 20250609.1.0)

We should revisit the lint action version as we are 2 versions behind at the moment (v8 vs v6)
However that could be a bigger change as [golangci-lint-action beyond 6  supports golangci version > 2 only](https://github.com/golangci/golangci-lint-action?tab=readme-ov-file#compatibility)

This PR will unblock all the new PRs

*Description of changes:*


*Testing done:*



- [ ] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
