### PR TITLE
feat: Use nerdctl parsing logic for port publishing

### DIFF
--- a/api/handlers/container/create.go
+++ b/api/handlers/container/create.go
@@ -9,13 +9,13 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 
 	"github.com/containerd/containerd/v2/pkg/namespaces"
 	gocni "github.com/containerd/go-cni"
 	ncTypes "github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/defaults"
+	"github.com/containerd/nerdctl/v2/pkg/portutil"
 	"github.com/docker/go-connections/nat"
 	"github.com/moby/moby/api/types/blkiodev"
 	"github.com/sirupsen/logrus"
@@ -320,7 +320,6 @@ func (h *handler) create(w http.ResponseWriter, r *http.Request) {
 		// #endregion
 
 	}
-
 	portMappings, err := translatePortMappings(req.HostConfig.PortBindings)
 	if err != nil {
 		logrus.Debugf("failed to parse port mappings: %s", err)
@@ -395,23 +394,23 @@ func translatePortMappings(portMappings nat.PortMap) ([]gocni.PortMapping, error
 	}
 	for portName, portBindings := range portMappings {
 		for _, portBinding := range portBindings {
-			hostPort, err := strconv.ParseInt(portBinding.HostPort, 10, 32)
+			// First we format the portbindings into a nerdctl compatible string format
+			portStr := ""
+			if portBinding.HostIP != "" {
+				portStr += portBinding.HostIP + ":"
+			}
+
+			// Add host port (or empty string if not specified)
+			portStr += portBinding.HostPort + ":"
+
+			// Add container port and protocol
+			portStr += portName.Port() + "/" + portName.Proto()
+
+			portMaps, err := portutil.ParseFlagP(portStr)
 			if err != nil {
-				return []gocni.PortMapping{}, fmt.Errorf("failed to parse host port (%s) to integer: %w", portBinding.HostPort, err)
+				return []gocni.PortMapping{}, fmt.Errorf("failed to parse port mapping %q: %w", portStr, err)
 			}
-			// Cannot use portName.Int() because it assumes nat.NewPort() was used
-			// for error handling.
-			containerPort, err := strconv.ParseInt(portName.Port(), 10, 32)
-			if err != nil {
-				return []gocni.PortMapping{}, fmt.Errorf("failed to parse container port (%s) to integer: %w", portName, err)
-			}
-			portMap := gocni.PortMapping{
-				HostPort:      int32(hostPort),
-				ContainerPort: int32(containerPort),
-				Protocol:      portName.Proto(),
-				HostIP:        portBinding.HostIP,
-			}
-			ports = append(ports, portMap)
+			ports = append(ports, portMaps...)
 		}
 	}
 	return ports, nil

--- a/api/handlers/container/create_test.go
+++ b/api/handlers/container/create_test.go
@@ -101,7 +101,7 @@ var _ = Describe("Container Create API ", func() {
 					HostPort:      8001,
 					ContainerPort: 8000,
 					Protocol:      "tcp",
-					HostIP:        "",
+					HostIP:        "0.0.0.0",
 				},
 				{
 					HostPort:      9001,
@@ -140,7 +140,7 @@ var _ = Describe("Container Create API ", func() {
 				"ExposedPorts": {"8000/tcp": {}},
 				"HostConfig": {
 					"PortBindings": {
-						"8000/tcp": [{"HostIp": "", "HostPort": ""}],
+						"8000/tcp": [{"HostIp": "", "HostPort": "invalid-port"}]
 					}
 				}
 			}`)


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
This PR uses ` portutil.ParseFlagP()` from nerdctl to parse the incoming portbinding request. ParseFlagP accepts port binding in string format, so we first translate the port binding from the docker api request to a nerdctl compatible string format. 

ParseFlagP has logic to allocate host port when empty, as well as checking for used host ports.

*Testing done:*
Added e2e test. Updated existing unit test.


- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
