### PR TITLE
ci: add finch vm testing

### DIFF
--- a/.github/workflows/finch-vm-test.yaml
+++ b/.github/workflows/finch-vm-test.yaml
@@ -1,0 +1,117 @@
+name: finch vm Tests
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - '**.md'
+  pull_request:
+    branches:
+      - main
+    paths-ignore:
+      - '**.md'
+  workflow_dispatch:
+env:
+  GO_VERSION: '1.23.8'
+jobs:
+  mac-vm-test:
+    runs-on: codebuild-finch-daemon-arm64-2-instance-${{ github.run_id }}-${{ github.run_attempt }}
+    timeout-minutes: 30
+    steps:
+      - name: Clean macOS runner workspace
+        run: |
+          rm -rf ${{ github.workspace }}/*
+      - name: Configure Git for ec2-user
+        run: |
+          # sudo chown -R ec2-user: /private
+          git config --global --add safe.directory "*"
+        shell: bash
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: false
+
+      - name: Configure Go for ec2-user
+        run: |
+          # Ensure Go is properly configured for ec2-user
+          chown -R ec2-user:staff $GOPATH || true
+          chown -R ec2-user:staff $RUNNER_TOOL_CACHE/go || true
+      - name: Install Rosetta 2
+        run: su ec2-user -c 'echo "A" | /usr/sbin/softwareupdate --install-rosetta --agree-to-license || true'
+
+      - name: Configure Homebrew for ec2-user
+        run: |
+          echo "Creating .brewrc file for ec2-user..."
+          cat > /Users/ec2-user/.brewrc << 'EOF'
+          # Homebrew environment setup
+          export PATH="/opt/homebrew/bin:/opt/homebrew/sbin:$PATH"
+          export HOMEBREW_PREFIX="/opt/homebrew"
+          export HOMEBREW_CELLAR="/opt/homebrew/Cellar"
+          export HOMEBREW_REPOSITORY="/opt/homebrew"
+          export HOMEBREW_NO_AUTO_UPDATE=1
+          EOF
+          chown ec2-user:staff /Users/ec2-user/.brewrc
+
+          # Fix Homebrew permissions
+          echo "Setting permissions for Homebrew directories..."
+          mkdir -p /opt/homebrew/Cellar
+          chown -R ec2-user:staff /opt/homebrew
+        shell: bash
+
+      # Install dependencies using ec2-user with custom environment
+      - name: Install dependencies
+        run: |
+          echo "Installing dependencies as ec2-user..."
+          # Run brew with custom environment
+          su ec2-user -c 'source /Users/ec2-user/.brewrc && brew install lz4 automake autoconf libtool yq'
+        shell: bash
+
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          # We need to get all the git tags to make version injection work. See VERSION in Makefile for more detail.
+          fetch-depth: 0
+          persist-credentials: false
+          submodules: recursive
+
+      - name: Configure workspace for ec2-user
+        run: |
+          # Ensure workspace is properly owned by ec2-user
+          chown -R ec2-user:staff ${{ github.workspace }}
+
+      # Install Finch
+      - name: Install Finch
+        run: |
+          echo "Installing Finch as ec2-user..."
+
+          # Run brew with custom environment
+          su ec2-user -c 'source /Users/ec2-user/.brewrc && brew install finch --cask'
+
+          # Verify installation
+          su ec2-user -c 'source /Users/ec2-user/.brewrc && brew list | grep finch || echo "finch not installed"'
+          mkdir -p /private/var/run/finch-lima
+          cat /etc/passwd
+          chown ec2-user:daemon /private/var/run/finch-lima
+        shell: bash
+
+      # Run e2e tests inside the Finch VM
+      - name: Run e2e tests
+        run: |
+          echo "Running e2e tests as root-user..."
+          su ec2-user -c 'cd ${{ github.workspace }} && STATIC=1 GOPROXY=direct GOOS=linux GOARCH=$(GOARCH) make'
+          # su ec2-user -c 'finch vm stop'
+          su ec2-user -c 'finch vm remove -f'
+
+          cp -f ${{ github.workspace }}/bin/finch-daemon /Applications/Finch/finch-daemon/finch-daemon
+          su ec2-user -c 'finch vm init'
+          su ec2-user -c 'make test-e2e-inside-vm'
+        shell: bash
+
+      # Cleanup
+      - name: Stop Finch VM
+        run: |
+          echo "Stopping Finch VM as ec2-user..."
+
+          # Stop VM using ec2-user with custom environment
+          su ec2-user -c "source /Users/ec2-user/.brewrc && HOME=/Users/ec2-user finch vm stop"
+        shell: bash
+        if: always()

--- a/Makefile
+++ b/Makefile
@@ -136,3 +136,25 @@ coverage: linux
 release: linux
 	@echo "$@"
 	@$(FINCH_DAEMON_PROJECT_ROOT)/scripts/create-releases.sh $(RELEASE_TAG)
+
+.PHONY: macos
+macos:
+ifeq ($(shell uname), Darwin)
+	@echo "Running on macOS"
+else
+	$(error This target can only be run on macOS!)
+endif
+	
+
+DAEMON_DOCKER_HOST := "unix:///Applications/Finch/lima/data/finch/sock/finch.sock"
+# DAEMON_ROOT
+
+.PHONY: test-e2e-inside-vm
+test-e2e-inside-vm: macos
+	DOCKER_HOST=$(DAEMON_DOCKER_HOST) \
+	DOCKER_API_VERSION="v1.41" \
+	TEST_E2E=1 \
+	go test ./e2e -test.v -ginkgo.v -ginkgo.randomize-all \
+	--subject="finch" \
+	--daemon-context-subject-prefix="/Applications/Finch/lima/bin/limactl shell finch sudo" \
+	--daemon-context-subject-env="LIMA_HOME=/Applications/Finch/lima/data"


### PR DESCRIPTION
Issue #, if available:

Run e2e tests within the finch vm, enabling us to find vm incompatibilities early 

*Description of changes:*

- Added a new workflow that uses codebuild mac runners to run finch vm
- Needs [#979: feat: add mac instances in codebuild project](https://github.com/runfinch/infrastructure/pull/979)

- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
