### PR TITLE
fix: verify release artifact docker-credential-finch

### DIFF
--- a/scripts/verify-release-artifacts.sh
+++ b/scripts/verify-release-artifacts.sh
@@ -45,7 +45,7 @@ release_version=${release_tag/v/}
 
 pushd "$release_dir" || exit 1
 tarballs=("finch-daemon-${release_version}-linux-${arch}.tar.gz" "finch-daemon-${release_version}-linux-${arch}-static.tar.gz")
-expected_contents=("finch-daemon" "THIRD_PARTY_LICENSES")
+expected_contents=("finch-daemon" "THIRD_PARTY_LICENSES" "docker-credential-finch")
 release_is_valid=true
 
 for t in "${tarballs[@]}"; do


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
fix release artifact checks to take docker-credential-finch binary

*Testing done:*



- [ ] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
