### PR TITLE
ci: Run e2e against different  nerdctl cli versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -74,15 +74,15 @@ jobs:
           name: build-artifacts
           path: build-artifacts.tar
   e2e-test:
+    name: e2e-test (containerd ${{ matrix.containerd }}, nerdctl ${{ matrix.nerdctl }})
     runs-on: ubuntu-latest
     needs: [build]
     strategy:
       matrix:
         containerd: ["1.7.27", "2.1.3"]
+        nerdctl: ["2.1.2", "2.1.3"]
       fail-fast: false
     timeout-minutes: 10
-    env:
-      CONTAINERD_VERSION: ${{ matrix.containerd }}
     steps:
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
@@ -94,7 +94,7 @@ jobs:
           sudo systemctl stop docker
           sudo systemctl stop containerd
       - name: Install Dependencies for e2e Testing
-        run: ./setup-test-env.sh
+        run: ./setup-test-env.sh --containerd-version ${{ matrix.containerd }} --nerdctl-version ${{ matrix.nerdctl }}
       - name: Download build artifacts
         uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
         with:

--- a/setup-test-env.sh
+++ b/setup-test-env.sh
@@ -1,9 +1,66 @@
 #!/bin/bash
-# Set versions
-RUNC_VERSION=1.3.0
-NERDCTL_VERSION=2.1.2
-BUILDKIT_VERSION=0.23.2
-CNI_VERSION=1.6.2
+
+DEFAULT_RUNC_VERSION="1.3.0"
+DEFAULT_CONTAINERD_VERSION="1.7.27"
+DEFAULT_NERDCTL_VERSION="2.1.3"
+DEFAULT_BUILDKIT_VERSION="0.23.2"
+DEFAULT_CNI_VERSION="1.6.2"
+
+# Parse command line arguments
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --runc-version)
+      RUNC_VERSION="$2"
+      shift 2
+      ;;
+    --containerd-version)
+      CONTAINERD_VERSION="$2"
+      shift 2
+      ;;
+    --nerdctl-version)
+      NERDCTL_VERSION="$2"
+      shift 2
+      ;;
+    --buildkit-version)
+      BUILDKIT_VERSION="$2"
+      shift 2
+      ;;
+    --cni-version)
+      CNI_VERSION="$2"
+      shift 2
+      ;;
+    --help)
+      echo "Usage: $0 [OPTIONS]"
+      echo "Options:"
+      echo "  --runc-version VERSION       Set runc version (default: $DEFAULT_RUNC_VERSION)"
+      echo "  --containerd-version VERSION Set containerd version (default: $DEFAULT_CONTAINERD_VERSION)"
+      echo "  --nerdctl-version VERSION    Set nerdctl version (default: $DEFAULT_NERDCTL_VERSION)"
+      echo "  --buildkit-version VERSION   Set buildkit version (default: $DEFAULT_BUILDKIT_VERSION)"
+      echo "  --cni-version VERSION        Set CNI plugins version (default: $DEFAULT_CNI_VERSION)"
+      echo "  --help                     Show this help message"
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1"
+      echo "Use --help for usage information"
+      exit 1
+      ;;
+  esac
+done
+
+# Set default versions if not provided
+CONTAINERD_VERSION=${CONTAINERD_VERSION:-$DEFAULT_CONTAINERD_VERSION}
+RUNC_VERSION=${RUNC_VERSION:-$DEFAULT_RUNC_VERSION}
+NERDCTL_VERSION=${NERDCTL_VERSION:-$DEFAULT_NERDCTL_VERSION}
+BUILDKIT_VERSION=${BUILDKIT_VERSION:-$DEFAULT_BUILDKIT_VERSION}
+CNI_VERSION=${CNI_VERSION:-$DEFAULT_CNI_VERSION}
+
+echo "Using dependency versions:"
+echo "  containerd: $CONTAINERD_VERSION"
+echo "  runc: $RUNC_VERSION"
+echo "  nerdctl: $NERDCTL_VERSION"
+echo "  buildkit: $BUILDKIT_VERSION"
+echo "  cni: $CNI_VERSION"
 
 apt update && apt install -y make gcc linux-libc-dev libseccomp-dev pkg-config git
 


### PR DESCRIPTION
Issue #, if available:
Adding capability to run e2e test against different versions of nerdctl cli. This is to ensure we have compatibility with older versions of nerdctl cli



- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
