### PR TITLE
chore: make security reporting template more visible

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,6 +7,11 @@ assignees: ''
 
 ---
 
+**Please do not report security issues through this template.** Refer to [Security](https://github.com/runfinch/finch-daemon?tab=security-ov-file#reporting-security-issues) for the proper reporting channels.
+
+---
+
+
 **Describe the bug**
 Briefly describe the problem you are having.
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,12 @@ following these steps:
 6. To enable the service on every reboot - `sudo systemctl enable finch.service`
 7. To disable the service on every reboot - `sudo systemctl disable finch.service`
 
+## Reporting an issue
+
+If you encounter anything that seems wrong, please check out our [issues](https://github.com/runfinch/finch-daemon/issues) tab first — someone may have already encountered your problem! If it's there, please add to the existing issue thread.
+
+If you can't find an existing issue, feel free to open a new one. As a remninder, anything related to security should NOT go through regular reporting channels. Please refer to [Security](https://github.com/runfinch/finch-daemon?tab=security-ov-file#reporting-security-issues) for guidance on how to report such issues.
+
 -----
 
 


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
Similar to https://github.com/runfinch/finch/pull/1560, adding a mention of the security reporting channels to our bug report template and our README.

*Testing done:*



- [X] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
