### PR TITLE
feat: remove dependency on nerdctl binary

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -114,14 +114,16 @@ jobs:
         run: ls -l ${{ github.workspace }}/docs/sample-rego-policies/example.rego
       - name: Set Rego file path
         run: echo "REGO_FILE_PATH=${{ github.workspace }}/docs/sample-rego-policies/example.rego" >> $GITHUB_ENV
+      - name: Install binaries
+        run: sudo make install
       - name: Start finch-daemon with opa Authz
-        run: sudo bin/finch-daemon --debug --experimental --rego-file ${{ github.workspace }}/docs/sample-rego-policies/example.rego --skip-rego-perm-check --socket-owner $UID --socket-addr /run/finch.sock --pidfile /run/finch.pid &
+        run: sudo /usr/local/bin/finch-daemon --debug --experimental --rego-file ${{ github.workspace }}/docs/sample-rego-policies/example.rego --skip-rego-perm-check --socket-owner $UID --socket-addr /run/finch.sock --pidfile /run/finch.pid &
       - name: Run opa e2e tests
         run: sudo -E make test-e2e-opa
       - name: Clean up Daemon socket
         run: sudo rm /run/finch.sock && sudo rm /run/finch.pid && sudo rm /run/finch-credential.sock
       - name: Start finch-daemon
-        run: sudo cp bin/docker-credential-finch /usr/bin && sudo bin/finch-daemon  --debug --socket-owner $UID &
+        run: sudo /usr/local/bin/finch-daemon --debug --socket-owner $UID &
       - name: Run e2e test
         run: sudo make test-e2e
       - name: Clean up Daemon socket

--- a/.github/workflows/finch-vm-test.yaml
+++ b/.github/workflows/finch-vm-test.yaml
@@ -106,12 +106,23 @@ jobs:
       - name: Make Finch Daemon
         run: |
           su ec2-user -c "cd $GITHUB_WORKSPACE/finch-daemon-pr && STATIC=1 GOPROXY=direct GOOS=linux GOARCH=\$(go env GOARCH) make"
+          su ec2-user -c "mkdir -p /Applications/Finch/finch-daemon"
           su ec2-user -c "cp $GITHUB_WORKSPACE/finch-daemon-pr/bin/finch-daemon /Applications/Finch/finch-daemon/finch-daemon"
+          su ec2-user -c "cp $GITHUB_WORKSPACE/finch-daemon-pr/bin/finch-hook /Applications/Finch/finch-daemon/finch-hook"
+          su ec2-user -c "cp $GITHUB_WORKSPACE/finch-daemon-pr/bin/docker-credential-finch /Applications/Finch/finch-daemon/docker-credential-finch"
 
       - name: Initializing Finch VM
         run: |
           su ec2-user -c 'finch vm init'
           su ec2-user -c 'while ! finch vm status | grep -q "Running"; do echo "Waiting for VM..."; sleep 5; done'
+          su ec2-user -c 'LIMA_HOME=/Applications/Finch/lima/data /Applications/Finch/lima/bin/limactl copy /Applications/Finch/finch-daemon/finch-daemon finch:/tmp/finch-daemon'
+          su ec2-user -c 'LIMA_HOME=/Applications/Finch/lima/data /Applications/Finch/lima/bin/limactl copy /Applications/Finch/finch-daemon/finch-hook finch:/tmp/finch-hook'
+          su ec2-user -c 'LIMA_HOME=/Applications/Finch/lima/data /Applications/Finch/lima/bin/limactl copy /Applications/Finch/finch-daemon/docker-credential-finch finch:/tmp/docker-credential-finch'
+          su ec2-user -c 'LIMA_HOME=/Applications/Finch/lima/data /Applications/Finch/lima/bin/limactl shell finch sudo install -m 755 /tmp/finch-daemon /usr/local/bin/finch-daemon'
+          su ec2-user -c 'LIMA_HOME=/Applications/Finch/lima/data /Applications/Finch/lima/bin/limactl shell finch sudo install -m 755 /tmp/finch-hook /usr/local/bin/finch-hook'
+          su ec2-user -c 'LIMA_HOME=/Applications/Finch/lima/data /Applications/Finch/lima/bin/limactl shell finch sudo install -m 755 /tmp/docker-credential-finch /usr/local/bin/docker-credential-finch'
+          su ec2-user -c 'LIMA_HOME=/Applications/Finch/lima/data /Applications/Finch/lima/bin/limactl shell finch sudo nohup /usr/local/bin/finch-daemon --debug --socket-owner 501 > /tmp/finch-daemon.log 2>&1 &'
+          sleep 5
 
       - name: Pinging Finch Daemon socket
         run: |

--- a/.github/workflows/samcli-direct.yaml
+++ b/.github/workflows/samcli-direct.yaml
@@ -84,6 +84,7 @@ jobs:
       - name: Build and start finch-daemon
         run: |
           make build
+          sudo make install
           sudo bin/finch-daemon --debug --socket-owner $UID 2>&1 | tee finch-daemon.log &
           sleep 10
 

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ CRED_HELPER_BINDIR ?= $(CRED_HELPER_PREFIX)/bin
 
 BINARY = $(addprefix bin/,finch-daemon)
 CREDENTIAL_HELPER = $(addprefix bin/,docker-credential-finch)
+HOOK_HELPER = $(addprefix bin/,finch-hook)
 
 PACKAGE := github.com/runfinch/finch-daemon
 VERSION ?= $(shell git describe --match 'v[0-9]*' --dirty='.modified' --always --tags)
@@ -28,7 +29,7 @@ endif
 LDFLAGS_BASE := -X $(PACKAGE)/version.Version=$(VERSION) -X $(PACKAGE)/version.GitCommit=$(GITCOMMIT) $(EXTRA_LDFLAGS)
 
 .PHONY: build
-build: build-daemon build-credential-helper
+build: build-daemon build-credential-helper build-hook-helper
 
 .PHONY: build-daemon
 build-daemon:
@@ -60,6 +61,21 @@ else
 		-v -o $(CREDENTIAL_HELPER) $(PACKAGE)/cmd/finch-credential-helper
 endif
 
+.PHONY: build-hook-helper
+build-hook-helper:
+ifeq ($(STATIC),)
+	@echo "Building Dynamic Hook Helper"
+	CGO_ENABLED=1 GOOS=linux go build \
+		-ldflags "$(LDFLAGS_BASE)" \
+		-v -o $(HOOK_HELPER) $(PACKAGE)/cmd/finch-hook
+else
+	@echo "Building Static Hook Helper"
+	CGO_ENABLED=0 GOOS=linux go build \
+		-tags netgo \
+		-ldflags "$(LDFLAGS_BASE) -extldflags '-static'" \
+		-v -o $(HOOK_HELPER) $(PACKAGE)/cmd/finch-hook
+endif
+
 clean:
 	@rm -f $(BINARIES)
 	@rm -rf $(BIN)
@@ -71,8 +87,9 @@ ifneq ($(shell uname), Linux)
 endif
 
 .PHONY: start
-start: linux build unlink
-	sudo $(BINARY) --debug --socket-owner $${UID}
+start: linux build install unlink
+	sudo mkdir -p /run/finch
+	sudo env PATH=/usr/local/bin:/usr/sbin:/sbin:/usr/bin:/bin /usr/local/bin/finch-daemon --debug --socket-owner $${UID}
 
 DLV=$(BIN)/dlv
 $(DLV):
@@ -83,22 +100,33 @@ start-debug: linux build $(DLV) unlink
 	sudo $(DLV) --listen=:2345 --headless=true --api-version=2 exec $(BINARY) -- --debug --socket-owner $${UID}
 
 install: linux
-	install -d $(DESTDIR)$(BINDIR)
-	install $(BINARY) $(DESTDIR)$(BINDIR)
-	install $(CREDENTIAL_HELPER) $(DESTDIR)$(CRED_HELPER_BINDIR)
+	sudo install -d $(DESTDIR)$(BINDIR)
+	sudo install $(BINARY) $(DESTDIR)$(BINDIR)
+	sudo install $(CREDENTIAL_HELPER) $(DESTDIR)$(CRED_HELPER_BINDIR)
+	sudo install $(HOOK_HELPER) $(DESTDIR)$(BINDIR)
 
 uninstall:
 	@rm -f $(addprefix $(DESTDIR)$(BINDIR)/,$(notdir $(BINARY)))
 	@rm -f $(addprefix $(DESTDIR)$(CRED_HELPER_BINDIR)/,$(notdir $(CREDENTIAL_HELPER)))
+	@rm -f $(addprefix $(DESTDIR)$(BINDIR)/,$(notdir $(HOOK_HELPER)))
+
+# Kill any running finch-daemon processes
+.PHONY: kill-daemon
+kill-daemon: linux
+	@sudo pkill -9 finch-daemon || true
+	@sleep 1
 
 # Unlink the unix socket if the link does not get cleaned up properly (or if finch-daemon is already running)
 .PHONY: unlink
-unlink: linux
+unlink: linux kill-daemon
 ifneq ("$(wildcard /run/finch.sock)","")
 	sudo unlink /run/finch.sock
 endif
 ifneq ("$(wildcard /run/finch/credential.sock)","")
 	sudo unlink /run/finch/credential.sock
+endif
+ifneq ("$(wildcard /run/finch.pid)","")
+	sudo rm /run/finch.pid
 endif
 
 .PHONY:  gen-code
@@ -135,14 +163,14 @@ test-unit-debug: linux $(DLV)
 	sudo $(DLV) --listen=:2345 --headless=true --api-version=2 test $(PKG_DIR)
 
 .PHONY: test-e2e
-test-e2e: linux
+test-e2e: linux install
 	DOCKER_HOST="unix:///run/finch.sock" \
 	DOCKER_API_VERSION="v1.41" \
 	TEST_E2E=1 \
 	$(GINKGO) $(GFLAGS) ./e2e/...
 
 .PHONY: test-e2e-opa
-test-e2e-opa: linux
+test-e2e-opa: linux install
 	DOCKER_HOST="unix:///run/finch.sock" \
 	DOCKER_API_VERSION="v1.41" \
 	MIDDLEWARE_E2E=1 \

--- a/api/handlers/system/events_test.go
+++ b/api/handlers/system/events_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"reflect"
 	"sync"
 	"time"
 
@@ -77,6 +78,7 @@ var _ = Describe("Events API", func() {
 
 		waitGroup.Add(1)
 		go func() {
+			defer GinkgoRecover()
 			defer waitGroup.Done()
 
 			h.events(rr, req)
@@ -129,6 +131,7 @@ var _ = Describe("Events API", func() {
 
 		waitGroup.Add(1)
 		go func() {
+			defer GinkgoRecover()
 			defer waitGroup.Done()
 
 			h.events(rr, req)
@@ -155,6 +158,7 @@ var _ = Describe("Events API", func() {
 
 		waitGroup.Add(1)
 		go func() {
+			defer GinkgoRecover()
 			defer waitGroup.Done()
 
 			h.events(rr, req)
@@ -186,14 +190,21 @@ var _ = Describe("Events API", func() {
 		req, err := http.NewRequest(http.MethodGet, url, nil)
 		Expect(err).Should(BeNil())
 
-		s.EXPECT().SubscribeEvents(req.Context(), map[string][]string{
-			"type":   {"container"},
-			"status": {"start", "stop"},
-		}).Return(mockEventCh, mockErrCh)
+		s.EXPECT().SubscribeEvents(req.Context(), gomock.Cond(func(x any) bool {
+			m, ok := x.(map[string][]string)
+			if !ok || len(m) != 2 {
+				return false
+			}
+			return reflect.DeepEqual(m["type"], []string{"container"}) &&
+				len(m["status"]) == 2 &&
+				((m["status"][0] == "start" && m["status"][1] == "stop") ||
+					(m["status"][0] == "stop" && m["status"][1] == "start"))
+		})).Return(mockEventCh, mockErrCh)
 		logger.EXPECT().Debugf("received error, exiting: %s", gomock.Any())
 
 		waitGroup.Add(1)
 		go func() {
+			defer GinkgoRecover()
 			defer waitGroup.Done()
 			h.events(rr, req)
 		}()

--- a/cmd/finch-daemon/router_utils.go
+++ b/cmd/finch-daemon/router_utils.go
@@ -74,14 +74,14 @@ func initializeConfig(options *DaemonOptions) (*config.Config, error) {
 	return conf, nil
 }
 
-// createNerdctlWrapper creates the Nerdctl wrapper and checks for the nerdctl binary.
+// createNerdctlWrapper creates the Nerdctl wrapper and checks for the finch-hook binary.
 func createNerdctlWrapper(clientWrapper *backend.ContainerdClientWrapper, conf *config.Config) (*backend.NerdctlWrapper, error) {
 	// GlobalCommandOptions is actually just an alias for Config, see
 	// https://github.com/containerd/nerdctl/blob/9f8655f7722d6e6851755123730436bf1a6c9995/pkg/api/types/global.go#L21
 	globalOptions := (*types.GlobalCommandOptions)(conf)
 	ncWrapper := backend.NewNerdctlWrapper(clientWrapper, globalOptions)
-	if _, err := ncWrapper.GetNerdctlExe(); err != nil {
-		return nil, fmt.Errorf("failed to find nerdctl binary: %w", err)
+	if _, err := ncWrapper.GetHookHelperBinary(); err != nil {
+		return nil, fmt.Errorf("failed to find hook helper binary: %w", err)
 	}
 	return ncWrapper, nil
 }

--- a/cmd/finch-hook/main.go
+++ b/cmd/finch-hook/main.go
@@ -1,0 +1,85 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/containerd/nerdctl/v2/cmd/nerdctl/helpers"
+	"github.com/containerd/nerdctl/v2/pkg/clientutil"
+	"github.com/containerd/nerdctl/v2/pkg/logging"
+	"github.com/containerd/nerdctl/v2/pkg/ocihook"
+	"github.com/spf13/cobra"
+)
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	if len(os.Args) == 3 && os.Args[1] == logging.MagicArgv1 {
+		return logging.Main(os.Args[2])
+	}
+	return newApp().Execute()
+}
+
+func newApp() *cobra.Command {
+	rootCmd := &cobra.Command{Use: "finch-hook"}
+	addPersistentFlags(rootCmd)
+
+	internalCmd := &cobra.Command{Use: "internal"}
+	ociHookCmd := &cobra.Command{
+		Use:           "oci-hook",
+		Short:         "OCI hook",
+		RunE:          internalOCIHookAction,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+	}
+
+	internalCmd.AddCommand(ociHookCmd)
+	rootCmd.AddCommand(internalCmd)
+	return rootCmd
+}
+
+func internalOCIHookAction(cmd *cobra.Command, args []string) error {
+	globalOptions, err := helpers.ProcessRootCmdFlags(cmd)
+	if err != nil {
+		return err
+	}
+	if len(args) == 0 {
+		return errors.New("event type needs to be passed")
+	}
+	dataStore, err := clientutil.DataStore(globalOptions.DataRoot, globalOptions.Address)
+	if err != nil {
+		return err
+	}
+	return ocihook.Run(os.Stdin, os.Stderr, args[0], dataStore, globalOptions.CNIPath, globalOptions.CNINetConfPath, globalOptions.BridgeIP)
+}
+
+func addPersistentFlags(cmd *cobra.Command) {
+	cmd.PersistentFlags().Bool("debug", false, "debug mode")
+	cmd.PersistentFlags().Bool("debug-full", false, "debug mode (with full output)")
+	cmd.PersistentFlags().String("address", "", "containerd address")
+	cmd.PersistentFlags().String("namespace", "", "containerd namespace")
+	cmd.PersistentFlags().String("snapshotter", "", "containerd snapshotter")
+	cmd.PersistentFlags().String("cni-path", "", "cni plugins binary directory")
+	cmd.PersistentFlags().String("cni-netconfpath", "", "cni config directory")
+	cmd.PersistentFlags().String("data-root", "", "Root directory of persistent nerdctl state")
+	cmd.PersistentFlags().String("cgroup-manager", "", "Cgroup manager to use")
+	cmd.PersistentFlags().Bool("insecure-registry", false, "skips verifying HTTPS certs")
+	cmd.PersistentFlags().StringSlice("hosts-dir", nil, "hosts directory")
+	cmd.PersistentFlags().Bool("experimental", false, "experimental features")
+	cmd.PersistentFlags().String("host-gateway-ip", "", "host gateway IP")
+	cmd.PersistentFlags().String("bridge-ip", "", "bridge IP")
+	cmd.PersistentFlags().Bool("kube-hide-dupe", false, "deduplicate images for k8s")
+	cmd.PersistentFlags().StringSlice("cdi-spec-dirs", nil, "CDI spec directories")
+	cmd.PersistentFlags().StringSlice("global-dns", nil, "global DNS servers")
+	cmd.PersistentFlags().StringSlice("global-dns-opts", nil, "global DNS options")
+	cmd.PersistentFlags().StringSlice("global-dns-search", nil, "global DNS search domains")
+}

--- a/cmd/finch-hook/main.go
+++ b/cmd/finch-hook/main.go
@@ -8,12 +8,26 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/containerd/nerdctl/v2/cmd/nerdctl/helpers"
 	"github.com/containerd/nerdctl/v2/pkg/clientutil"
+	"github.com/containerd/nerdctl/v2/pkg/fs"
 	"github.com/containerd/nerdctl/v2/pkg/logging"
 	"github.com/containerd/nerdctl/v2/pkg/ocihook"
 	"github.com/spf13/cobra"
 )
+
+// hookOptions holds the only values that finch-hook needs at OCI hook time.
+// finch-hook is a single-purpose binary and intentionally does not use
+// helpers.ProcessRootCmdFlags from nerdctl — that helper requires all 19 nerdctl
+// global flags to be registered and reads many fields irrelevant to the hook path.
+// This struct is scoped to exactly what nerdctl's ocihook.Run and
+// clientutil.DataStore actually consume.
+type hookOptions struct {
+	address        string
+	dataRoot       string
+	cniPath        string
+	cniNetconfPath string
+	bridgeIP       string
+}
 
 func main() {
 	if err := run(); err != nil {
@@ -48,38 +62,55 @@ func newApp() *cobra.Command {
 }
 
 func internalOCIHookAction(cmd *cobra.Command, args []string) error {
-	globalOptions, err := helpers.ProcessRootCmdFlags(cmd)
+	opts, err := parseHookOptions(cmd)
 	if err != nil {
 		return err
 	}
 	if len(args) == 0 {
 		return errors.New("event type needs to be passed")
 	}
-	dataStore, err := clientutil.DataStore(globalOptions.DataRoot, globalOptions.Address)
+	dataStore, err := clientutil.DataStore(opts.dataRoot, opts.address)
 	if err != nil {
 		return err
 	}
-	return ocihook.Run(os.Stdin, os.Stderr, args[0], dataStore, globalOptions.CNIPath, globalOptions.CNINetConfPath, globalOptions.BridgeIP)
+	return ocihook.Run(os.Stdin, os.Stderr, args[0], dataStore, opts.cniPath, opts.cniNetconfPath, opts.bridgeIP)
 }
 
 func addPersistentFlags(cmd *cobra.Command) {
-	cmd.PersistentFlags().Bool("debug", false, "debug mode")
-	cmd.PersistentFlags().Bool("debug-full", false, "debug mode (with full output)")
+	// finch-hook only registers the flags it actually uses. It intentionally does not
+	// use helpers.ProcessRootCmdFlags, which requires all 19 nerdctl global flags to be
+	// present. These 5 flags are the complete surface area of the finch-hook binary.
 	cmd.PersistentFlags().String("address", "", "containerd address")
-	cmd.PersistentFlags().String("namespace", "", "containerd namespace")
-	cmd.PersistentFlags().String("snapshotter", "", "containerd snapshotter")
+	cmd.PersistentFlags().String("data-root", "", "root directory of persistent finch-daemon state")
 	cmd.PersistentFlags().String("cni-path", "", "cni plugins binary directory")
 	cmd.PersistentFlags().String("cni-netconfpath", "", "cni config directory")
-	cmd.PersistentFlags().String("data-root", "", "Root directory of persistent nerdctl state")
-	cmd.PersistentFlags().String("cgroup-manager", "", "Cgroup manager to use")
-	cmd.PersistentFlags().Bool("insecure-registry", false, "skips verifying HTTPS certs")
-	cmd.PersistentFlags().StringSlice("hosts-dir", nil, "hosts directory")
-	cmd.PersistentFlags().Bool("experimental", false, "experimental features")
-	cmd.PersistentFlags().String("host-gateway-ip", "", "host gateway IP")
 	cmd.PersistentFlags().String("bridge-ip", "", "bridge IP")
-	cmd.PersistentFlags().Bool("kube-hide-dupe", false, "deduplicate images for k8s")
-	cmd.PersistentFlags().StringSlice("cdi-spec-dirs", nil, "CDI spec directories")
-	cmd.PersistentFlags().StringSlice("global-dns", nil, "global DNS servers")
-	cmd.PersistentFlags().StringSlice("global-dns-opts", nil, "global DNS options")
-	cmd.PersistentFlags().StringSlice("global-dns-search", nil, "global DNS search domains")
+}
+
+// parseHookOptions reads the 5 flags that finch-hook registers and initialises
+// the filesystem helper (fs.InitFS), preserving the side effect that
+// helpers.ProcessRootCmdFlags performs in the full nerdctl CLI.
+func parseHookOptions(cmd *cobra.Command) (hookOptions, error) {
+	var opts hookOptions
+	var err error
+
+	if opts.address, err = cmd.Flags().GetString("address"); err != nil {
+		return hookOptions{}, err
+	}
+	if opts.dataRoot, err = cmd.Flags().GetString("data-root"); err != nil {
+		return hookOptions{}, err
+	}
+	if opts.cniPath, err = cmd.Flags().GetString("cni-path"); err != nil {
+		return hookOptions{}, err
+	}
+	if opts.cniNetconfPath, err = cmd.Flags().GetString("cni-netconfpath"); err != nil {
+		return hookOptions{}, err
+	}
+	if opts.bridgeIP, err = cmd.Flags().GetString("bridge-ip"); err != nil {
+		return hookOptions{}, err
+	}
+	if err = fs.InitFS(opts.dataRoot); err != nil {
+		return hookOptions{}, err
+	}
+	return opts, nil
 }

--- a/cmd/finch-hook/main_test.go
+++ b/cmd/finch-hook/main_test.go
@@ -31,7 +31,6 @@ func TestNewApp_ParsesOCIHookArgs(t *testing.T) {
 	app := newApp()
 	app.SetArgs([]string{
 		"--address=/run/containerd/containerd.sock",
-		"--namespace=finch",
 		"--data-root=/tmp/test",
 		"--cni-path=/opt/cni/bin",
 		"--cni-netconfpath=/etc/cni/net.d",
@@ -59,19 +58,25 @@ func TestAddPersistentFlags(t *testing.T) {
 	app := newApp()
 	flags := app.PersistentFlags()
 
-	// All flags read by helpers.ProcessRootCmdFlags
+	// finch-hook only registers the 5 flags it actually consumes.
+	// It intentionally does not register the full nerdctl global flagset —
+	// see addPersistentFlags and parseHookOptions in main.go.
 	requiredFlags := []string{
-		"debug", "debug-full",
-		"address", "namespace", "snapshotter",
-		"cni-path", "cni-netconfpath", "data-root",
-		"cgroup-manager", "insecure-registry", "hosts-dir",
-		"experimental", "host-gateway-ip", "bridge-ip",
-		"kube-hide-dupe", "cdi-spec-dirs",
-		"global-dns", "global-dns-opts", "global-dns-search",
+		"address", "data-root", "cni-path", "cni-netconfpath", "bridge-ip",
+	}
+	for _, name := range requiredFlags {
+		assert.NotNil(t, flags.Lookup(name), "missing required persistent flag %q", name)
 	}
 
-	for _, name := range requiredFlags {
-		assert.NotNil(t, flags.Lookup(name), "missing required persistent flag %q (needed by helpers.ProcessRootCmdFlags)", name)
+	// Flags that belonged to the old nerdctl global flagset but are not consumed
+	// by finch-hook should NOT be registered.
+	removedFlags := []string{
+		"debug", "debug-full", "namespace", "snapshotter", "cgroup-manager",
+		"insecure-registry", "hosts-dir", "experimental", "host-gateway-ip",
+		"kube-hide-dupe", "cdi-spec-dirs", "global-dns", "global-dns-opts", "global-dns-search",
+	}
+	for _, name := range removedFlags {
+		assert.Nil(t, flags.Lookup(name), "flag %q should not be registered in finch-hook", name)
 	}
 }
 

--- a/cmd/finch-hook/main_test.go
+++ b/cmd/finch-hook/main_test.go
@@ -1,0 +1,81 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"testing"
+
+	"github.com/containerd/nerdctl/v2/pkg/logging"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewApp_CommandStructure(t *testing.T) {
+	app := newApp()
+	assert.Equal(t, "finch-hook", app.Use)
+
+	// Verify "internal" subcommand exists
+	internalCmd, _, err := app.Find([]string{"internal"})
+	require.NoError(t, err, "'internal' subcommand should exist")
+	assert.Equal(t, "internal", internalCmd.Use)
+
+	// Verify "internal oci-hook" subcommand exists
+	ociHookCmd, _, err := app.Find([]string{"internal", "oci-hook"})
+	require.NoError(t, err, "'internal oci-hook' subcommand should exist")
+	assert.Equal(t, "oci-hook", ociHookCmd.Use)
+	assert.NotNil(t, ociHookCmd.RunE, "oci-hook command should have RunE set")
+}
+
+func TestNewApp_ParsesOCIHookArgs(t *testing.T) {
+	app := newApp()
+	app.SetArgs([]string{
+		"--address=/run/containerd/containerd.sock",
+		"--namespace=finch",
+		"--data-root=/tmp/test",
+		"--cni-path=/opt/cni/bin",
+		"--cni-netconfpath=/etc/cni/net.d",
+		"internal", "oci-hook", "createRuntime",
+	})
+
+	// Execute will fail at ocihook.Run (no valid OCI state on stdin),
+	// but flag parsing and command routing should succeed.
+	err := app.Execute()
+	require.Error(t, err)
+	// The error should NOT be a flag parsing error
+	assert.NotContains(t, err.Error(), "unknown flag")
+}
+
+func TestNewApp_OCIHookRequiresEventType(t *testing.T) {
+	app := newApp()
+	app.SetArgs([]string{"internal", "oci-hook"})
+
+	err := app.Execute()
+	require.Error(t, err)
+	assert.Equal(t, "event type needs to be passed", err.Error())
+}
+
+func TestAddPersistentFlags(t *testing.T) {
+	app := newApp()
+	flags := app.PersistentFlags()
+
+	// All flags read by helpers.ProcessRootCmdFlags
+	requiredFlags := []string{
+		"debug", "debug-full",
+		"address", "namespace", "snapshotter",
+		"cni-path", "cni-netconfpath", "data-root",
+		"cgroup-manager", "insecure-registry", "hosts-dir",
+		"experimental", "host-gateway-ip", "bridge-ip",
+		"kube-hide-dupe", "cdi-spec-dirs",
+		"global-dns", "global-dns-opts", "global-dns-search",
+	}
+
+	for _, name := range requiredFlags {
+		assert.NotNil(t, flags.Lookup(name), "missing required persistent flag %q (needed by helpers.ProcessRootCmdFlags)", name)
+	}
+}
+
+func TestLoggingMagicArgv(t *testing.T) {
+	assert.Equal(t, "_NERDCTL_INTERNAL_LOGGING", logging.MagicArgv1,
+		"MagicArgv1 constant should match expected value used in run()")
+}

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -139,6 +139,9 @@ func runContainerTests(opt *option.Option, pOpt func([]string, ...option.Modifie
 	tests.ContainerInspect(opt, pOpt)
 	tests.ContainerWait(opt)
 	tests.ContainerPause(opt)
+	tests.FinchhookNetworking(opt)
+	tests.FinchhookLogging(opt)
+	tests.FinchhookStartup()
 }
 
 // functional test for volume APIs.

--- a/e2e/tests/finch_hook_logging.go
+++ b/e2e/tests/finch_hook_logging.go
@@ -1,0 +1,98 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// TODO(remove-nerdctl-full-integration): All command.*(opt, ...) calls in this file must be
+// converted to HTTP API calls when merging remove-nerdctl-binary-dep and remove-test-dependency.
+// See .kiro/specs/finch-hook-helper-binary/hook-test-gap.md for the migration plan.
+
+package tests
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/runfinch/common-tests/command"
+	"github.com/runfinch/common-tests/option"
+
+	"github.com/runfinch/finch-daemon/api/types"
+	"github.com/runfinch/finch-daemon/e2e/client"
+)
+
+// FinchhookLogging tests that the log URI binary:// path is correctly set to finch-hook
+// by verifying that GET /containers/{id}/logs returns the expected output after a container
+// created via the HTTP API writes to stdout.
+func FinchhookLogging(opt *option.Option) {
+	Describe("finch-hook log URI", func() {
+		var (
+			uClient *http.Client
+			version string
+			url     string
+		)
+		BeforeEach(func() {
+			uClient = client.NewClient(GetDockerHostUrl())
+			version = GetDockerApiVersion()
+			url = client.ConvertToFinchUrl(version, "/containers/create")
+		})
+		AfterEach(func() {
+			command.RemoveAll(opt)
+		})
+
+		It("should return stdout via GET /logs after container created through HTTP API, confirming log URI points to finch-hook", func() {
+			options := types.ContainerCreateRequest{}
+			options.Image = defaultImage
+			options.Cmd = []string{"echo", "finch-hook-log-test"}
+
+			statusCode, ctr := createContainer(uClient, url, testContainerName, options)
+			Expect(statusCode).Should(Equal(http.StatusCreated))
+			Expect(ctr.ID).ShouldNot(BeEmpty())
+
+			// Start the container and let it run to completion.
+			command.Run(opt, "start", testContainerName)
+			time.Sleep(1 * time.Second)
+
+			// Retrieve logs via the HTTP API — not via nerdctl CLI.
+			// If the log URI was set to finch-hook correctly, containerd will invoke
+			// finch-hook in logging mode and the output will be available here.
+			logsURL := fmt.Sprintf("/containers/%s/logs?stdout=1&stderr=1&follow=0&tail=0", testContainerName)
+			res, err := uClient.Get(client.ConvertToFinchUrl(version, logsURL))
+			Expect(err).Should(BeNil())
+			body, err := io.ReadAll(res.Body)
+			Expect(err).Should(BeNil())
+			_ = res.Body.Close()
+
+			Expect(res.StatusCode).Should(Equal(http.StatusOK))
+			// The Docker multiplexed stream format prefixes each line with an 8-byte header.
+			// body[8:] is the first log line payload.
+			Expect(string(body)).Should(ContainSubstring("finch-hook-log-test"))
+		})
+
+		It("should return logs for a container that produces multiple lines, confirming streaming works end-to-end", func() {
+			options := types.ContainerCreateRequest{}
+			options.Image = defaultImage
+			options.Cmd = []string{"sh", "-c", "echo line1; echo line2; echo line3"}
+
+			statusCode, ctr := createContainer(uClient, url, testContainerName, options)
+			Expect(statusCode).Should(Equal(http.StatusCreated))
+			Expect(ctr.ID).ShouldNot(BeEmpty())
+
+			command.Run(opt, "start", testContainerName)
+			time.Sleep(1 * time.Second)
+
+			logsURL := fmt.Sprintf("/containers/%s/logs?stdout=1&stderr=1&follow=0&tail=0", testContainerName)
+			res, err := uClient.Get(client.ConvertToFinchUrl(version, logsURL))
+			Expect(err).Should(BeNil())
+			body, err := io.ReadAll(res.Body)
+			Expect(err).Should(BeNil())
+			_ = res.Body.Close()
+
+			Expect(res.StatusCode).Should(Equal(http.StatusOK))
+			Expect(string(body)).Should(ContainSubstring("line1"))
+			Expect(string(body)).Should(ContainSubstring("line2"))
+			Expect(string(body)).Should(ContainSubstring("line3"))
+		})
+	})
+}

--- a/e2e/tests/finch_hook_networking.go
+++ b/e2e/tests/finch_hook_networking.go
@@ -1,0 +1,124 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// TODO(remove-nerdctl-full-integration): All command.*(opt, ...) calls in this file must be
+// converted to HTTP API calls when merging remove-nerdctl-binary-dep and remove-test-dependency.
+// See .kiro/specs/finch-hook-helper-binary/hook-test-gap.md for the migration plan.
+
+package tests
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/docker/go-connections/nat"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/runfinch/common-tests/command"
+	"github.com/runfinch/common-tests/option"
+
+	"github.com/runfinch/finch-daemon/api/types"
+	"github.com/runfinch/finch-daemon/e2e/client"
+)
+
+// FinchhookNetworking tests that CNI hooks ran correctly via finch-hook by verifying
+// that a container attached to a bridge network receives an IP address and can reach
+// external addresses. These tests confirm the OCI createRuntime/poststop hook pipeline
+// is wired to finch-hook rather than nerdctl.
+func FinchhookNetworking(opt *option.Option) {
+	Describe("finch-hook CNI networking", func() {
+		var (
+			uClient *http.Client
+			version string
+			url     string
+		)
+		BeforeEach(func() {
+			uClient = client.NewClient(GetDockerHostUrl())
+			version = GetDockerApiVersion()
+			url = client.ConvertToFinchUrl(version, "/containers/create")
+		})
+		AfterEach(func() {
+			command.RemoveAll(opt)
+		})
+
+		It("should assign an IP address to a container on the bridge network, confirming CNI hooks ran", func() {
+			options := types.ContainerCreateRequest{}
+			options.Image = defaultImage
+			options.Cmd = []string{"sleep", "Infinity"}
+
+			statusCode, ctr := createContainer(uClient, url, testContainerName, options)
+			Expect(statusCode).Should(Equal(http.StatusCreated))
+			Expect(ctr.ID).ShouldNot(BeEmpty())
+
+			command.Run(opt, "start", testContainerName)
+
+			// IP assignment is the observable proof that the CNI hook fired.
+			// If finch-hook failed to run, the container would have no network interface.
+			verifyNetworkSettings(opt, testContainerName, "bridge")
+		})
+
+		It("should allow a container to reach an external address, confirming CNI masquerade rules are set", func() {
+			options := types.ContainerCreateRequest{}
+			options.Image = defaultImage
+			// wget with a short timeout so the test fails fast if networking is broken.
+			// We only care about the TCP handshake succeeding (exit 0), not the HTTP response.
+			options.Cmd = []string{"wget", "-q", "--spider", "--timeout=5", "http://example.com"}
+
+			statusCode, ctr := createContainer(uClient, url, testContainerName, options)
+			Expect(statusCode).Should(Equal(http.StatusCreated))
+			Expect(ctr.ID).ShouldNot(BeEmpty())
+
+			// start -a waits for the container to exit and returns its stdout.
+			// A zero exit from wget confirms outbound connectivity via CNI.
+			out := command.StdoutStr(opt, "start", "-a", testContainerName)
+			_ = out // wget --spider writes nothing to stdout on success
+		})
+
+		It("should attach a container to a user-defined bridge network with correct IP settings", func() {
+			command.Run(opt, "network", "create", testNetwork)
+
+			options := types.ContainerCreateRequest{}
+			options.Image = defaultImage
+			options.Cmd = []string{"sleep", "Infinity"}
+			options.HostConfig.NetworkMode = testNetwork
+
+			statusCode, ctr := createContainer(uClient, url, testContainerName, options)
+			Expect(statusCode).Should(Equal(http.StatusCreated))
+			Expect(ctr.ID).ShouldNot(BeEmpty())
+
+			command.Run(opt, "start", testContainerName)
+			verifyNetworkSettings(opt, testContainerName, testNetwork)
+		})
+
+		It("should publish a port and make it reachable from the host, confirming nerdctl/ports labels were written", func() {
+			// Run a minimal HTTP server inside the container on port 8080.
+			// busybox httpd is available in the alpine image.
+			options := types.ContainerCreateRequest{}
+			options.Image = defaultImage
+			options.Cmd = []string{
+				"sh", "-c",
+				`mkdir -p /www && echo "ok" > /www/index.html && httpd -p 8080 -h /www && sleep 30`,
+			}
+			options.HostConfig.PortBindings = nat.PortMap{
+				"8080/tcp": []nat.PortBinding{{HostIP: "127.0.0.1", HostPort: "18080"}},
+			}
+
+			statusCode, ctr := createContainer(uClient, url, testContainerName, options)
+			Expect(statusCode).Should(Equal(http.StatusCreated))
+			Expect(ctr.ID).ShouldNot(BeEmpty())
+
+			command.Run(opt, "start", testContainerName)
+
+			// Give httpd a moment to start.
+			time.Sleep(2 * time.Second)
+
+			// Verify the published port is reachable from the host.
+			// This confirms the nerdctl/ports label was written and the OCI hook processed it.
+			resp, err := http.Get("http://127.0.0.1:18080/index.html") //nolint:noctx
+			Expect(err).Should(BeNil(), fmt.Sprintf("published port 18080 not reachable: container ID %s", ctr.ID))
+			Expect(resp.StatusCode).Should(Equal(http.StatusOK))
+			_ = resp.Body.Close()
+		})
+	})
+}

--- a/e2e/tests/finch_hook_networking.go
+++ b/e2e/tests/finch_hook_networking.go
@@ -92,16 +92,17 @@ func FinchhookNetworking(opt *option.Option) {
 		})
 
 		It("should publish a port and make it reachable from the host, confirming nerdctl/ports labels were written", func() {
-			// Run a minimal HTTP server inside the container on port 8080.
-			// busybox httpd is available in the alpine image.
+			// nginx serves HTTP on port 80 with no configuration needed and is already
+			// pulled as part of the test suite setup — no alpine tooling assumptions.
 			options := types.ContainerCreateRequest{}
-			options.Image = defaultImage
-			options.Cmd = []string{
-				"sh", "-c",
-				`mkdir -p /www && echo "ok" > /www/index.html && httpd -p 8080 -h /www && sleep 30`,
+			options.Image = nginxImage
+			// ExposedPorts must be set so nerdctl writes the nerdctl/ports label,
+			// which the OCI hook reads to configure port forwarding rules.
+			options.ExposedPorts = nat.PortSet{
+				"80/tcp": struct{}{},
 			}
 			options.HostConfig.PortBindings = nat.PortMap{
-				"8080/tcp": []nat.PortBinding{{HostIP: "127.0.0.1", HostPort: "18080"}},
+				"80/tcp": []nat.PortBinding{{HostIP: "127.0.0.1", HostPort: "18080"}},
 			}
 
 			statusCode, ctr := createContainer(uClient, url, testContainerName, options)
@@ -110,12 +111,12 @@ func FinchhookNetworking(opt *option.Option) {
 
 			command.Run(opt, "start", testContainerName)
 
-			// Give httpd a moment to start.
+			// Give nginx a moment to start.
 			time.Sleep(2 * time.Second)
 
 			// Verify the published port is reachable from the host.
 			// This confirms the nerdctl/ports label was written and the OCI hook processed it.
-			resp, err := http.Get("http://127.0.0.1:18080/index.html") //nolint:noctx
+			resp, err := http.Get("http://127.0.0.1:18080/") //nolint:noctx // test helper, no request cancellation needed
 			Expect(err).Should(BeNil(), fmt.Sprintf("published port 18080 not reachable: container ID %s", ctr.ID))
 			Expect(resp.StatusCode).Should(Equal(http.StatusOK))
 			_ = resp.Body.Close()

--- a/e2e/tests/finch_hook_startup.go
+++ b/e2e/tests/finch_hook_startup.go
@@ -32,7 +32,7 @@ func FinchhookStartup() {
 			// Simpler approach: just strip any directory that contains finch-hook.
 			cleanPath := pathWithoutBinary("finch-hook")
 
-			cmd := exec.Command(daemonExe) //nolint:gosec
+			cmd := exec.Command(daemonExe) //nolint:gosec // path is resolved from a known env var or hardcoded fallback, not user input
 			cmd.Env = append(os.Environ(), "PATH="+cleanPath)
 
 			var stderr bytes.Buffer

--- a/e2e/tests/finch_hook_startup.go
+++ b/e2e/tests/finch_hook_startup.go
@@ -1,0 +1,95 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package tests
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// FinchhookStartup tests that finch-daemon fails fast at startup when finch-hook is absent
+// from PATH, rather than silently failing at container create time.
+// This test is self-contained: it does not use the shared daemon started by the test suite.
+// It starts its own short-lived daemon process with a sanitised PATH.
+func FinchhookStartup() {
+	Describe("finch-daemon startup without finch-hook", func() {
+		It("should exit with a non-zero status and reference finch-hook in the error output", func() {
+			daemonExe := GetFinchDaemonExe()
+			if _, err := os.Stat(daemonExe); os.IsNotExist(err) {
+				Skip("finch-daemon binary not found at " + daemonExe + "; skipping startup test")
+			}
+
+			// Build a PATH that contains everything except finch-hook.
+			// We do this by constructing a temp dir with symlinks to every binary in PATH
+			// except finch-hook, then setting that as the only PATH entry.
+			// Simpler approach: just strip any directory that contains finch-hook.
+			cleanPath := pathWithoutBinary("finch-hook")
+
+			cmd := exec.Command(daemonExe) //nolint:gosec
+			cmd.Env = append(os.Environ(), "PATH="+cleanPath)
+
+			var stderr bytes.Buffer
+			cmd.Stderr = &stderr
+
+			// The daemon should exit quickly once it fails the startup check.
+			// We give it 5 seconds; if it hasn't exited by then something is wrong.
+			err := runWithTimeout(cmd, 5*time.Second)
+
+			// We expect a non-zero exit — either the process exited with an error,
+			// or it timed out (which means it didn't fail fast, also a test failure).
+			Expect(err).ShouldNot(BeNil(), "expected daemon to exit with error when finch-hook is absent")
+
+			errOutput := stderr.String()
+			Expect(errOutput).Should(ContainSubstring("finch-hook"),
+				"expected error output to reference finch-hook, got: %s", errOutput)
+		})
+	})
+}
+
+// pathWithoutBinary returns a PATH string that excludes any directory containing
+// the named binary. This lets us simulate finch-hook being absent without modifying
+// the filesystem.
+func pathWithoutBinary(binary string) string {
+	original := os.Getenv("PATH")
+	dirs := strings.Split(original, ":")
+	var filtered []string
+	for _, dir := range dirs {
+		candidate := dir + "/" + binary
+		if _, err := os.Stat(candidate); os.IsNotExist(err) {
+			filtered = append(filtered, dir)
+		}
+	}
+	return strings.Join(filtered, ":")
+}
+
+// runWithTimeout starts cmd and waits up to timeout for it to exit.
+// Returns the exit error if the process exited with non-zero status,
+// or a timeout error if it did not exit in time.
+func runWithTimeout(cmd *exec.Cmd, timeout time.Duration) error {
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	done := make(chan error, 1)
+	go func() { done <- cmd.Wait() }()
+
+	select {
+	case err := <-done:
+		return err
+	case <-time.After(timeout):
+		_ = cmd.Process.Kill()
+		return &timeoutError{timeout: timeout}
+	}
+}
+
+type timeoutError struct{ timeout time.Duration }
+
+func (e *timeoutError) Error() string {
+	return "process did not exit within " + e.timeout.String()
+}

--- a/go.mod
+++ b/go.mod
@@ -54,6 +54,7 @@ require (
 	github.com/agnivade/levenshtein v1.2.1 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+	github.com/compose-spec/compose-go/v2 v2.10.0 // indirect
 	github.com/containerd/nerdctl/mod/tigron v0.0.0-20250720235051-d775a8c42fbb // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.0 // indirect
 	github.com/go-ini/ini v1.67.0 // indirect
@@ -69,6 +70,7 @@ require (
 	github.com/lestrrat-go/jwx/v3 v3.0.12 // indirect
 	github.com/lestrrat-go/option/v2 v2.0.0 // indirect
 	github.com/lufia/plan9stats v0.0.0-20251013123823-9fd1530e3ec3 // indirect
+	github.com/mattn/go-shellwords v1.0.12 // indirect
 	github.com/moby/sys/capability v0.4.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 // indirect
@@ -77,6 +79,7 @@ require (
 	github.com/prometheus/common v0.67.4 // indirect
 	github.com/prometheus/procfs v0.19.2 // indirect
 	github.com/rcrowley/go-metrics v0.0.0-20250401214520-65e299d6c5c9 // indirect
+	github.com/santhosh-tekuri/jsonschema/v6 v6.0.1 // indirect
 	github.com/segmentio/asm v1.2.1 // indirect
 	github.com/shoenig/go-m1cpu v0.1.7 // indirect
 	github.com/tchap/go-patricia/v2 v2.3.3 // indirect
@@ -86,13 +89,16 @@ require (
 	github.com/vektah/gqlparser/v2 v2.5.31 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
+	github.com/xhit/go-str2duration/v2 v2.1.0 // indirect
 	github.com/yashtewari/glob-intersection v0.2.0 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel/sdk v1.40.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
+	go.yaml.in/yaml/v4 v4.0.0-rc.3 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20251222181119-0a764e51fe1b // indirect
+	gotest.tools/v3 v3.5.2 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -114,6 +114,8 @@ github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5Qvfr
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
 github.com/djherbis/times v1.6.0 h1:w2ctJ92J8fBvWPxugmXIv7Nz7Q3iDMKNx9v5ocVH20c=
 github.com/djherbis/times v1.6.0/go.mod h1:gOHeRAz2h+VJNZ5Gmc/o7iD9k4wW7NMVqieYCY99oc0=
+github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
+github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/docker/cli v28.5.2+incompatible h1:XmG99IHcBmIAoC1PPg9eLBZPlTrNUAijsHLm8PjhBlg=
 github.com/docker/cli v28.5.2+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/docker v28.5.2+incompatible h1:DBX0Y0zAjZbSrm1uzOkdr1onVghKaftjlSWt4AFexzM=
@@ -653,7 +655,6 @@ gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
 gotest.tools/v3 v3.5.2 h1:7koQfIKdy+I8UTetycgUqXWSDwpgv193Ka+qRsmBY8Q=
 gotest.tools/v3 v3.5.2/go.mod h1:LtdLGcnqToBH83WByAAi/wiwSFCArdFIUV/xxN4pcjA=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/internal/backend/backend_test.go
+++ b/internal/backend/backend_test.go
@@ -1,0 +1,16 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package backend
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestBackend(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "UnitTests - Backend")
+}

--- a/internal/backend/container.go
+++ b/internal/backend/container.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"os/exec"
 
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
@@ -141,14 +140,13 @@ func (w *NerdctlWrapper) ContainerTop(ctx context.Context, cid string, options t
 }
 
 func (w *NerdctlWrapper) GetHookHelperBinary() (string, error) {
-	if w.nerdctlExe != "" {
-		return w.nerdctlExe, nil
+	if w.hookHelperExe != "" {
+		return w.hookHelperExe, nil
 	}
-	// Look for finch-hook binary instead of nerdctl
-	exe, err := exec.LookPath("finch-hook")
+	exe, err := w.lookPath("finch-hook")
 	if err != nil {
 		return "", fmt.Errorf("finch-hook binary not found in PATH: %w", err)
 	}
-	w.nerdctlExe = exe
+	w.hookHelperExe = exe
 	return exe, nil
 }

--- a/internal/backend/container.go
+++ b/internal/backend/container.go
@@ -44,8 +44,8 @@ type NerdctlContainerSvc interface {
 	LoggingInitContainerLogViewer(containerLabels map[string]string, lvopts logging.LogViewOptions, stopChannel chan os.Signal, experimental bool) (contlv *logging.ContainerLogViewer, err error)
 	LoggingPrintLogsTo(stdout, stderr io.Writer, clv *logging.ContainerLogViewer) error
 
-	// GetNerdctlExe returns a path to the nerdctl binary, which is required for setting up OCI hooks and logging
-	GetNerdctlExe() (string, error)
+	// GetHookHelperBinary returns a path to the finch-hook binary, which is required for setting up OCI hooks and logging
+	GetHookHelperBinary() (string, error)
 }
 
 func (w *NerdctlWrapper) RemoveContainer(ctx context.Context, c containerd.Container, force bool, removeVolumes bool) error {
@@ -140,13 +140,14 @@ func (w *NerdctlWrapper) ContainerTop(ctx context.Context, cid string, options t
 	return container.Top(ctx, w.clientWrapper.client, []string{cid}, options)
 }
 
-func (w *NerdctlWrapper) GetNerdctlExe() (string, error) {
+func (w *NerdctlWrapper) GetHookHelperBinary() (string, error) {
 	if w.nerdctlExe != "" {
 		return w.nerdctlExe, nil
 	}
-	exe, err := exec.LookPath("nerdctl")
+	// Look for finch-hook binary instead of nerdctl
+	exe, err := exec.LookPath("finch-hook")
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("finch-hook binary not found in PATH: %w", err)
 	}
 	w.nerdctlExe = exe
 	return exe, nil

--- a/internal/backend/container_test.go
+++ b/internal/backend/container_test.go
@@ -1,0 +1,69 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package backend
+
+import (
+	"errors"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("GetHookHelperBinary", func() {
+	var w *NerdctlWrapper
+
+	BeforeEach(func() {
+		w = &NerdctlWrapper{}
+	})
+
+	It("returns the resolved path on first call", func() {
+		w.lookPath = func(name string) (string, error) {
+			Expect(name).To(Equal("finch-hook"))
+			return "/usr/local/bin/finch-hook", nil
+		}
+
+		path, err := w.GetHookHelperBinary()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(path).To(Equal("/usr/local/bin/finch-hook"))
+	})
+
+	It("caches the result and calls lookPath exactly once on repeated calls", func() {
+		callCount := 0
+		w.lookPath = func(name string) (string, error) {
+			callCount++
+			return "/usr/local/bin/finch-hook", nil
+		}
+
+		first, err := w.GetHookHelperBinary()
+		Expect(err).NotTo(HaveOccurred())
+
+		second, err := w.GetHookHelperBinary()
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(first).To(Equal(second))
+		Expect(callCount).To(Equal(1), "lookPath should be called exactly once; cached on second call")
+	})
+
+	It("returns an error containing 'finch-hook binary not found in PATH' when lookPath fails", func() {
+		w.lookPath = func(name string) (string, error) {
+			return "", errors.New("not found")
+		}
+
+		_, err := w.GetHookHelperBinary()
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("finch-hook binary not found in PATH"))
+	})
+
+	It("returns the pre-set path without calling lookPath when hookHelperExe is already set", func() {
+		w.hookHelperExe = "/custom/path/finch-hook"
+		w.lookPath = func(name string) (string, error) {
+			Fail("lookPath should not be called when hookHelperExe is already cached")
+			return "", nil
+		}
+
+		path, err := w.GetHookHelperBinary()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(path).To(Equal("/custom/path/finch-hook"))
+	})
+})

--- a/internal/backend/nerdctl.go
+++ b/internal/backend/nerdctl.go
@@ -5,6 +5,7 @@ package backend
 
 import (
 	"os"
+	"os/exec"
 
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/netutil"
@@ -16,15 +17,18 @@ import (
 type NerdctlWrapper struct {
 	clientWrapper *ContainerdClientWrapper
 	globalOptions *types.GlobalCommandOptions
-	nerdctlExe    string
-	netClient     *netutil.CNIEnv
-	CNI           *libcni.CNIConfig
+	hookHelperExe string
+	// lookPath is exec.LookPath by default; overridable in tests.
+	lookPath  func(string) (string, error)
+	netClient *netutil.CNIEnv
+	CNI       *libcni.CNIConfig
 }
 
 func NewNerdctlWrapper(clientWrapper *ContainerdClientWrapper, options *types.GlobalCommandOptions) *NerdctlWrapper {
 	return &NerdctlWrapper{
 		clientWrapper: clientWrapper,
 		globalOptions: options,
+		lookPath:      exec.LookPath,
 		netClient: &netutil.CNIEnv{
 			Path:        options.CNIPath,
 			NetconfPath: options.CNINetConfPath,

--- a/internal/service/container/create.go
+++ b/internal/service/container/create.go
@@ -21,14 +21,36 @@ import (
 )
 
 func (s *service) Create(ctx context.Context, image string, cmd []string, createOpt types.ContainerCreateOptions, netOpt types.NetworkOptions) (cid string, err error) {
-	// Set path to nerdctl binary required for OCI hooks and logging
+	// Set path to finch-hook binary required for OCI hooks and logging
 	if createOpt.NerdctlCmd == "" {
-		ncExe, err := s.nctlContainerSvc.GetNerdctlExe()
+		ncExe, err := s.nctlContainerSvc.GetHookHelperBinary()
 		if err != nil {
-			return "", fmt.Errorf("failed to find nerdctl binary: %s", err)
+			return "", fmt.Errorf("failed to find hook helper binary: %s", err)
 		}
 		createOpt.NerdctlCmd = ncExe
-		createOpt.NerdctlArgs = []string{}
+		// Populate args with global options needed by the hook binary
+		// These match what nerdctl CLI would pass to itself when generating OCI hooks
+		createOpt.NerdctlArgs = []string{
+			"--address=" + createOpt.GOptions.Address,
+			"--namespace=" + createOpt.GOptions.Namespace,
+			"--data-root=" + createOpt.GOptions.DataRoot,
+			"--cni-path=" + createOpt.GOptions.CNIPath,
+			"--cni-netconfpath=" + createOpt.GOptions.CNINetConfPath,
+			"--snapshotter=" + createOpt.GOptions.Snapshotter,
+			"--cgroup-manager=" + createOpt.GOptions.CgroupManager,
+		}
+		// Add optional flags if they are set
+		if len(createOpt.GOptions.HostsDir) > 0 {
+			for _, dir := range createOpt.GOptions.HostsDir {
+				createOpt.NerdctlArgs = append(createOpt.NerdctlArgs, "--hosts-dir="+dir)
+			}
+		}
+		if createOpt.GOptions.BridgeIP != "" {
+			createOpt.NerdctlArgs = append(createOpt.NerdctlArgs, "--bridge-ip="+createOpt.GOptions.BridgeIP)
+		}
+		if createOpt.GOptions.HostGatewayIP != "" {
+			createOpt.NerdctlArgs = append(createOpt.NerdctlArgs, "--host-gateway-ip="+createOpt.GOptions.HostGatewayIP)
+		}
 	}
 
 	netManager, err := s.nctlContainerSvc.NewNetworkingOptionsManager(netOpt)
@@ -80,7 +102,7 @@ func updateContainerMetadata(ctx context.Context, createOpt types.ContainerCreat
 
 	// Handle log URI reset
 	// NOTE: this is a temporary workaround to fix logging issue described in https://github.com/containerd/nerdctl/issues/2264.
-	// The refactored create method in nerdctl uses self exe (finch-daemon) binary for logging instead of nerdctl binary path.
+	// The refactored create method in nerdctl uses self exe (finch-daemon) binary for logging instead of finch-hook binary path.
 	// The following workaround resets this logging binary in the OCI spec and handles port labels for backward compatibility.
 	// TODO: remove this workaround when the issue is resolved upstream.
 	dataStore, err := clientutil.DataStore(createOpt.GOptions.DataRoot, createOpt.GOptions.Address)
@@ -104,7 +126,7 @@ func updateContainerMetadata(ctx context.Context, createOpt types.ContainerCreat
 	// Handle port labels for backward compatibility with nerdctl 2.1.2.
 	// nerdctl 2.1.3 changed the port publishing logic to use a dedicated portstore instead of container labels.
 	// Though nerdctl itself is backward compatible, newer library versions will no longer create the port labels,
-	// which is not compatible with older nerdctl executables needed to run the OCI hooks for setting up the network.
+	// which is not compatible with finch-hook binary needed to run the OCI hooks for setting up the network.
 	if len(netOpt.PortMappings) > 0 {
 		portsJSON, err := json.Marshal(netOpt.PortMappings)
 		if err != nil {

--- a/internal/service/container/create.go
+++ b/internal/service/container/create.go
@@ -28,28 +28,24 @@ func (s *service) Create(ctx context.Context, image string, cmd []string, create
 			return "", fmt.Errorf("failed to find hook helper binary: %s", err)
 		}
 		createOpt.NerdctlCmd = ncExe
-		// Populate args with global options needed by the hook binary
-		// These match what nerdctl CLI would pass to itself when generating OCI hooks
+		// Populate the minimal set of flags that finch-hook actually consumes.
+		// internalOCIHookAction reads only 5 fields from GlobalCommandOptions after parsing:
+		//   DataRoot + Address → clientutil.DataStore (constructs the dataStore path)
+		//   CNIPath, CNINetConfPath, BridgeIP → passed directly to ocihook.Run
+		// All other flags (--namespace, --snapshotter, --cgroup-manager, --hosts-dir,
+		// --host-gateway-ip, etc.) are parsed but never referenced in the hook path.
+		// --hosts-dir is image-resolution-only; --host-gateway-ip is resolved at create time
+		// into OCI spec annotations and the hook reads the pre-resolved values from there.
 		createOpt.NerdctlArgs = []string{
 			"--address=" + createOpt.GOptions.Address,
-			"--namespace=" + createOpt.GOptions.Namespace,
 			"--data-root=" + createOpt.GOptions.DataRoot,
 			"--cni-path=" + createOpt.GOptions.CNIPath,
 			"--cni-netconfpath=" + createOpt.GOptions.CNINetConfPath,
-			"--snapshotter=" + createOpt.GOptions.Snapshotter,
-			"--cgroup-manager=" + createOpt.GOptions.CgroupManager,
 		}
-		// Add optional flags if they are set
-		if len(createOpt.GOptions.HostsDir) > 0 {
-			for _, dir := range createOpt.GOptions.HostsDir {
-				createOpt.NerdctlArgs = append(createOpt.NerdctlArgs, "--hosts-dir="+dir)
-			}
-		}
+		// BridgeIP is passed to ocihook.Run → WithDefaultNetwork. Empty string is safe
+		// (falls back to DefaultCIDR), but a non-empty value must be forwarded.
 		if createOpt.GOptions.BridgeIP != "" {
 			createOpt.NerdctlArgs = append(createOpt.NerdctlArgs, "--bridge-ip="+createOpt.GOptions.BridgeIP)
-		}
-		if createOpt.GOptions.HostGatewayIP != "" {
-			createOpt.NerdctlArgs = append(createOpt.NerdctlArgs, "--host-gateway-ip="+createOpt.GOptions.HostGatewayIP)
 		}
 	}
 

--- a/internal/service/container/create_test.go
+++ b/internal/service/container/create_test.go
@@ -55,7 +55,18 @@ var _ = Describe("Container Create API ", func() {
 		image = "test-image"
 		cmd = []string{"echo", "hello world"}
 		createOpt = types.ContainerCreateOptions{}
-		createOptExp = types.ContainerCreateOptions{NerdctlCmd: ncExe, NerdctlArgs: []string{}}
+		createOptExp = types.ContainerCreateOptions{
+			NerdctlCmd: ncExe,
+			NerdctlArgs: []string{
+				"--address=",
+				"--namespace=",
+				"--data-root=",
+				"--cni-path=",
+				"--cni-netconfpath=",
+				"--snapshotter=",
+				"--cgroup-manager=",
+			},
+		}
 		netOpt = types.NetworkOptions{}
 		netManager = mocks_container.NewMockNetworkOptionsManager(mockCtrl)
 		cid = "test-container-id"
@@ -72,7 +83,7 @@ var _ = Describe("Container Create API ", func() {
 	})
 	Context("service", func() {
 		It("should successfully create a container", func() {
-			ncContainerSvc.EXPECT().GetNerdctlExe().Return(ncExe, nil)
+			ncContainerSvc.EXPECT().GetHookHelperBinary().Return(ncExe, nil)
 			ncContainerSvc.EXPECT().NewNetworkingOptionsManager(netOpt).Return(netManager, nil)
 
 			// container create arguments
@@ -91,7 +102,7 @@ var _ = Describe("Container Create API ", func() {
 		})
 		It("should return internal error for network options create failure", func() {
 			mockErr := errors.New("error while creating networking options")
-			ncContainerSvc.EXPECT().GetNerdctlExe().Return(ncExe, nil)
+			ncContainerSvc.EXPECT().GetHookHelperBinary().Return(ncExe, nil)
 			ncContainerSvc.EXPECT().NewNetworkingOptionsManager(gomock.Any()).Return(nil, mockErr)
 
 			// service should return with an error
@@ -100,7 +111,7 @@ var _ = Describe("Container Create API ", func() {
 			Expect(err.Error()).Should(Equal(mockErr.Error()))
 		})
 		It("should return internal error for container create failure", func() {
-			ncContainerSvc.EXPECT().GetNerdctlExe().Return(ncExe, nil)
+			ncContainerSvc.EXPECT().GetHookHelperBinary().Return(ncExe, nil)
 			ncContainerSvc.EXPECT().NewNetworkingOptionsManager(netOpt).Return(netManager, nil)
 
 			// container create arguments
@@ -117,7 +128,7 @@ var _ = Describe("Container Create API ", func() {
 			Expect(err.Error()).Should(Equal(mockErr.Error()))
 		})
 		It("should call garbage collector upon container create failure", func() {
-			ncContainerSvc.EXPECT().GetNerdctlExe().Return(ncExe, nil)
+			ncContainerSvc.EXPECT().GetHookHelperBinary().Return(ncExe, nil)
 			ncContainerSvc.EXPECT().NewNetworkingOptionsManager(netOpt).Return(netManager, nil)
 
 			// container create arguments
@@ -141,7 +152,7 @@ var _ = Describe("Container Create API ", func() {
 			Expect(err.Error()).Should(Equal(mockErr.Error()))
 		})
 		It("should return not-found error if image was not found", func() {
-			ncContainerSvc.EXPECT().GetNerdctlExe().Return(ncExe, nil)
+			ncContainerSvc.EXPECT().GetHookHelperBinary().Return(ncExe, nil)
 			ncContainerSvc.EXPECT().NewNetworkingOptionsManager(netOpt).Return(netManager, nil)
 
 			// container create arguments
@@ -157,7 +168,7 @@ var _ = Describe("Container Create API ", func() {
 			Expect(errdefs.IsNotFound(err)).Should(BeTrue())
 		})
 		It("should return invalid-format error if the inputs are invalid", func() {
-			ncContainerSvc.EXPECT().GetNerdctlExe().Return(ncExe, nil)
+			ncContainerSvc.EXPECT().GetHookHelperBinary().Return(ncExe, nil)
 			ncContainerSvc.EXPECT().NewNetworkingOptionsManager(netOpt).Return(netManager, nil)
 
 			// container create arguments
@@ -173,7 +184,7 @@ var _ = Describe("Container Create API ", func() {
 			Expect(errdefs.IsInvalidFormat(err)).Should(BeTrue())
 		})
 		It("should return conflict error if container name already exists", func() {
-			ncContainerSvc.EXPECT().GetNerdctlExe().Return(ncExe, nil)
+			ncContainerSvc.EXPECT().GetHookHelperBinary().Return(ncExe, nil)
 			ncContainerSvc.EXPECT().NewNetworkingOptionsManager(netOpt).Return(netManager, nil)
 
 			// container create arguments
@@ -189,8 +200,8 @@ var _ = Describe("Container Create API ", func() {
 			Expect(errdefs.IsConflict(err)).Should(BeTrue())
 		})
 		It("should return an error if nerdctl binary was not found", func() {
-			mockErr := errors.New("could not find nerdctl binary")
-			ncContainerSvc.EXPECT().GetNerdctlExe().Return("", mockErr)
+			mockErr := errors.New("could not find hook helper binary")
+			ncContainerSvc.EXPECT().GetHookHelperBinary().Return("", mockErr)
 
 			// service should return with an error
 			cidResult, err := svc.Create(ctx, image, nil, createOpt, netOpt)

--- a/internal/service/container/create_test.go
+++ b/internal/service/container/create_test.go
@@ -51,7 +51,7 @@ var _ = Describe("Container Create API ", func() {
 		cdClient = mocks_backend.NewMockContainerdClient(mockCtrl)
 		ncContainerSvc = mocks_backend.NewMockNerdctlContainerSvc(mockCtrl)
 		ncNetworkSvc = mocks_backend.NewMockNerdctlNetworkSvc(mockCtrl)
-		ncExe = "/usr/local/bin/nerdctl"
+		ncExe = "/usr/local/bin/finch-hook"
 		image = "test-image"
 		cmd = []string{"echo", "hello world"}
 		createOpt = types.ContainerCreateOptions{}
@@ -59,12 +59,9 @@ var _ = Describe("Container Create API ", func() {
 			NerdctlCmd: ncExe,
 			NerdctlArgs: []string{
 				"--address=",
-				"--namespace=",
 				"--data-root=",
 				"--cni-path=",
 				"--cni-netconfpath=",
-				"--snapshotter=",
-				"--cgroup-manager=",
 			},
 		}
 		netOpt = types.NetworkOptions{}
@@ -199,7 +196,7 @@ var _ = Describe("Container Create API ", func() {
 			Expect(cidResult).Should(BeEmpty())
 			Expect(errdefs.IsConflict(err)).Should(BeTrue())
 		})
-		It("should return an error if nerdctl binary was not found", func() {
+		It("should return an error if finch-hook binary was not found", func() {
 			mockErr := errors.New("could not find hook helper binary")
 			ncContainerSvc.EXPECT().GetHookHelperBinary().Return("", mockErr)
 

--- a/mocks/mocks_backend/nerdctlcontainersvc.go
+++ b/mocks/mocks_backend/nerdctlcontainersvc.go
@@ -108,19 +108,19 @@ func (mr *MockNerdctlContainerSvcMockRecorder) GetDataStore() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDataStore", reflect.TypeOf((*MockNerdctlContainerSvc)(nil).GetDataStore))
 }
 
-// GetNerdctlExe mocks base method.
-func (m *MockNerdctlContainerSvc) GetNerdctlExe() (string, error) {
+// GetHookHelperBinary mocks base method.
+func (m *MockNerdctlContainerSvc) GetHookHelperBinary() (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetNerdctlExe")
+	ret := m.ctrl.Call(m, "GetHookHelperBinary")
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetNerdctlExe indicates an expected call of GetNerdctlExe.
-func (mr *MockNerdctlContainerSvcMockRecorder) GetNerdctlExe() *gomock.Call {
+// GetHookHelperBinary indicates an expected call of GetHookHelperBinary.
+func (mr *MockNerdctlContainerSvcMockRecorder) GetHookHelperBinary() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNerdctlExe", reflect.TypeOf((*MockNerdctlContainerSvc)(nil).GetNerdctlExe))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHookHelperBinary", reflect.TypeOf((*MockNerdctlContainerSvc)(nil).GetHookHelperBinary))
 }
 
 // InspectContainer mocks base method.


### PR DESCRIPTION
*Description of changes:* finch-daemon currently uses the nerdctl binary for OCI hooks and logging. We can extract relevant logic from nerdctl into a custom binary and use it in place of the original nerdctl binary.

*Testing done:* Container unit tests work locally, though they are mocks. I also manually tested it by setting the DOCKER_HOST and checking container operations worked as expected. However, I need to use CI to see if the use of the new binary instead of the nerdctl binary maintains functionality of finch-daemon.

- [x] I've reviewed the guidance in CONTRIBUTING.md

#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.